### PR TITLE
Get most watches building on scarthgap

### DIFF
--- a/meta-anthias/recipes-kernel/linux/linux-anthias/0013-ARM-8933-1-replace-Sun-Solaris-style-flag-on-section.patch
+++ b/meta-anthias/recipes-kernel/linux/linux-anthias/0013-ARM-8933-1-replace-Sun-Solaris-style-flag-on-section.patch
@@ -1,0 +1,116 @@
+From 52b7b0ea9d9e4672dfc742f71cc6b08a8d10ffa7 Mon Sep 17 00:00:00 2001
+From: casept <davids.paskevics@gmail.com>
+Date: Sun, 16 Jun 2024 00:51:52 +0200
+Subject: [PATCH] ARM: 8933/1: replace Sun/Solaris style flag on section
+ directive
+
+It looks like a section directive was using "Solaris style" to declare
+the section flags. Replace this with the GNU style so that Clang's
+integrated assembler can assemble this directive.
+
+The modified instances were identified via:
+$ ag \.section | grep #
+
+Link: https://ftp.gnu.org/old-gnu/Manuals/gas-2.9.1/html_chapter/as_7.html#SEC119
+Link: https://github.com/ClangBuiltLinux/linux/issues/744
+Link: https://bugs.llvm.org/show_bug.cgi?id=43759
+Link: https://reviews.llvm.org/D69296
+
+Acked-by: Nicolas Pitre <nico@fluxnic.net>
+Reviewed-by: Ard Biesheuvel <ardb@kernel.org>
+Reviewed-by: Stefan Agner <stefan@agner.ch>
+Signed-off-by: Nick Desaulniers <ndesaulniers@google.com>
+Suggested-by: Fangrui Song <maskray@google.com>
+Suggested-by: Jian Cai <jiancai@google.com>
+Suggested-by: Peter Smith <peter.smith@linaro.org>
+Signed-off-by: Russell King <rmk+kernel@armlinux.org.uk>
+[ partial backport to 3.10 ]
+---
+ arch/arm/boot/compressed/big-endian.S   | 2 +-
+ arch/arm/boot/compressed/head.S         | 2 +-
+ arch/arm/boot/compressed/piggy.gzip.S   | 2 +-
+ arch/arm/boot/compressed/piggy.lzma.S   | 2 +-
+ arch/arm/boot/compressed/piggy.lzo.S    | 2 +-
+ arch/arm/boot/compressed/piggy.xzkern.S | 2 +-
+ arch/arm/mm/proc-v7.S                   | 2 +-
+ 7 files changed, 7 insertions(+), 7 deletions(-)
+
+diff --git a/arch/arm/boot/compressed/big-endian.S b/arch/arm/boot/compressed/big-endian.S
+index 25ab26f1c6f0..f22428e275f8 100644
+--- a/arch/arm/boot/compressed/big-endian.S
++++ b/arch/arm/boot/compressed/big-endian.S
+@@ -5,7 +5,7 @@
+  *  Author: Nicolas Pitre
+  */
+ 
+-	.section ".start", #alloc, #execinstr
++	.section ".start", "ax"
+ 
+ 	mrc	p15, 0, r0, c1, c0, 0	@ read control reg
+ 	orr	r0, r0, #(1 << 7)	@ enable big endian mode
+diff --git a/arch/arm/boot/compressed/head.S b/arch/arm/boot/compressed/head.S
+index fdd2e354ba3f..c5057234b014 100644
+--- a/arch/arm/boot/compressed/head.S
++++ b/arch/arm/boot/compressed/head.S
+@@ -114,7 +114,7 @@
+ #endif
+ 		.endm
+ 
+-		.section ".start", #alloc, #execinstr
++		.section ".start", "ax"
+ /*
+  * sort out different calling conventions
+  */
+diff --git a/arch/arm/boot/compressed/piggy.gzip.S b/arch/arm/boot/compressed/piggy.gzip.S
+index a68adf91a165..175ed02a6ac3 100644
+--- a/arch/arm/boot/compressed/piggy.gzip.S
++++ b/arch/arm/boot/compressed/piggy.gzip.S
+@@ -1,4 +1,4 @@
+-	.section .piggydata,#alloc
++	.section .piggydata, "a"
+ 	.globl	input_data
+ input_data:
+ 	.incbin	"arch/arm/boot/compressed/piggy.gzip"
+diff --git a/arch/arm/boot/compressed/piggy.lzma.S b/arch/arm/boot/compressed/piggy.lzma.S
+index d7e69cffbc0a..cfea81ae8f4b 100644
+--- a/arch/arm/boot/compressed/piggy.lzma.S
++++ b/arch/arm/boot/compressed/piggy.lzma.S
+@@ -1,4 +1,4 @@
+-	.section .piggydata,#alloc
++	.section .piggydata, "a"
+ 	.globl	input_data
+ input_data:
+ 	.incbin	"arch/arm/boot/compressed/piggy.lzma"
+diff --git a/arch/arm/boot/compressed/piggy.lzo.S b/arch/arm/boot/compressed/piggy.lzo.S
+index a425ad95959a..236976d8dc7d 100644
+--- a/arch/arm/boot/compressed/piggy.lzo.S
++++ b/arch/arm/boot/compressed/piggy.lzo.S
+@@ -1,4 +1,4 @@
+-	.section .piggydata,#alloc
++	.section .piggydata, "a"
+ 	.globl	input_data
+ input_data:
+ 	.incbin	"arch/arm/boot/compressed/piggy.lzo"
+diff --git a/arch/arm/boot/compressed/piggy.xzkern.S b/arch/arm/boot/compressed/piggy.xzkern.S
+index 5703f300d027..a135d3b549c5 100644
+--- a/arch/arm/boot/compressed/piggy.xzkern.S
++++ b/arch/arm/boot/compressed/piggy.xzkern.S
+@@ -1,4 +1,4 @@
+-	.section .piggydata,#alloc
++	.section .piggydata, "a"
+ 	.globl	input_data
+ input_data:
+ 	.incbin	"arch/arm/boot/compressed/piggy.xzkern"
+diff --git a/arch/arm/mm/proc-v7.S b/arch/arm/mm/proc-v7.S
+index 1f8597462b3a..050e3da34b9f 100644
+--- a/arch/arm/mm/proc-v7.S
++++ b/arch/arm/mm/proc-v7.S
+@@ -417,7 +417,7 @@ __v7_setup_stack:
+ 	string	cpu_elf_name, "v7"
+ 	.align
+ 
+-	.section ".proc.info.init", #alloc, #execinstr
++	.section ".proc.info.init", "ax"
+ 
+ 	/*
+ 	 * Standard v7 proc info content

--- a/meta-anthias/recipes-kernel/linux/linux-anthias_mm-dr1.bb
+++ b/meta-anthias/recipes-kernel/linux/linux-anthias_mm-dr1.bb
@@ -9,21 +9,22 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=d7810fab7487fb0aad327b76f1be7cd7"
 COMPATIBLE_MACHINE = "anthias"
 
 SRC_URI = "git://android.googlesource.com/kernel/msm;branch=android-msm-anthias-3.10-marshmallow-dr1-wear-release;protocol=https \
-    file://defconfig \
-    file://img_info \
-    file://0001-scripts-dtc-Remove-redundant-YYLOC-global-declaratio.patch \
-    file://0002-Create-copy-of-devfreq_trace.h.patch \
-    file://0003-msm-mdss-mdp-Don-t-use-tracing-features.patch \
-    file://0004-psmouse-base-disable-references-to-lifebook_detect-w.patch \
-    file://0005-static-inline-in-ARM-ftrace.h.patch \
-    file://0006-traps-only-use-unwind_backtrace-if-available.patch \
-    file://0007-Use-Bluesleep-instead-of-Nitrous-for-BT-power-manage.patch \
-    file://0008-Backport-mainline-4.1-Bluetooth-subsystem.patch \
-    file://0009-it7260-Add-delay-for-wakeup-report.patch \
-    file://0010-ARM-uaccess-remove-put_user-code-duplication.patch \
-    file://0011-random-introduce-getrandom-2-system-call.patch \
-    file://0012-ARM-wire-up-getrandom-syscall.patch \
-"
+           file://defconfig \
+           file://img_info \
+           file://0001-scripts-dtc-Remove-redundant-YYLOC-global-declaratio.patch \
+           file://0002-Create-copy-of-devfreq_trace.h.patch \
+           file://0003-msm-mdss-mdp-Don-t-use-tracing-features.patch \
+           file://0004-psmouse-base-disable-references-to-lifebook_detect-w.patch \
+           file://0005-static-inline-in-ARM-ftrace.h.patch \
+           file://0006-traps-only-use-unwind_backtrace-if-available.patch \
+           file://0007-Use-Bluesleep-instead-of-Nitrous-for-BT-power-manage.patch \
+           file://0008-Backport-mainline-4.1-Bluetooth-subsystem.patch \
+           file://0009-it7260-Add-delay-for-wakeup-report.patch \
+           file://0010-ARM-uaccess-remove-put_user-code-duplication.patch \
+           file://0011-random-introduce-getrandom-2-system-call.patch \
+           file://0012-ARM-wire-up-getrandom-syscall.patch \
+           file://0013-ARM-8933-1-replace-Sun-Solaris-style-flag-on-section.patch \
+           "
 SRCREV = "5d054632429188226b8c1e1e545475c89ad4c582"
 LINUX_VERSION ?= "3.10"
 PV = "${LINUX_VERSION}+marshmallow"

--- a/meta-bass/recipes-kernel/linux/linux-bass/0009-ARM-8933-1-replace-Sun-Solaris-style-flag-on-section.patch
+++ b/meta-bass/recipes-kernel/linux/linux-bass/0009-ARM-8933-1-replace-Sun-Solaris-style-flag-on-section.patch
@@ -1,0 +1,116 @@
+From 52b7b0ea9d9e4672dfc742f71cc6b08a8d10ffa7 Mon Sep 17 00:00:00 2001
+From: casept <davids.paskevics@gmail.com>
+Date: Sun, 16 Jun 2024 00:51:52 +0200
+Subject: [PATCH] ARM: 8933/1: replace Sun/Solaris style flag on section
+ directive
+
+It looks like a section directive was using "Solaris style" to declare
+the section flags. Replace this with the GNU style so that Clang's
+integrated assembler can assemble this directive.
+
+The modified instances were identified via:
+$ ag \.section | grep #
+
+Link: https://ftp.gnu.org/old-gnu/Manuals/gas-2.9.1/html_chapter/as_7.html#SEC119
+Link: https://github.com/ClangBuiltLinux/linux/issues/744
+Link: https://bugs.llvm.org/show_bug.cgi?id=43759
+Link: https://reviews.llvm.org/D69296
+
+Acked-by: Nicolas Pitre <nico@fluxnic.net>
+Reviewed-by: Ard Biesheuvel <ardb@kernel.org>
+Reviewed-by: Stefan Agner <stefan@agner.ch>
+Signed-off-by: Nick Desaulniers <ndesaulniers@google.com>
+Suggested-by: Fangrui Song <maskray@google.com>
+Suggested-by: Jian Cai <jiancai@google.com>
+Suggested-by: Peter Smith <peter.smith@linaro.org>
+Signed-off-by: Russell King <rmk+kernel@armlinux.org.uk>
+[ partial backport to 3.10 ]
+---
+ arch/arm/boot/compressed/big-endian.S   | 2 +-
+ arch/arm/boot/compressed/head.S         | 2 +-
+ arch/arm/boot/compressed/piggy.gzip.S   | 2 +-
+ arch/arm/boot/compressed/piggy.lzma.S   | 2 +-
+ arch/arm/boot/compressed/piggy.lzo.S    | 2 +-
+ arch/arm/boot/compressed/piggy.xzkern.S | 2 +-
+ arch/arm/mm/proc-v7.S                   | 2 +-
+ 7 files changed, 7 insertions(+), 7 deletions(-)
+
+diff --git a/arch/arm/boot/compressed/big-endian.S b/arch/arm/boot/compressed/big-endian.S
+index 25ab26f1c6f0..f22428e275f8 100644
+--- a/arch/arm/boot/compressed/big-endian.S
++++ b/arch/arm/boot/compressed/big-endian.S
+@@ -5,7 +5,7 @@
+  *  Author: Nicolas Pitre
+  */
+ 
+-	.section ".start", #alloc, #execinstr
++	.section ".start", "ax"
+ 
+ 	mrc	p15, 0, r0, c1, c0, 0	@ read control reg
+ 	orr	r0, r0, #(1 << 7)	@ enable big endian mode
+diff --git a/arch/arm/boot/compressed/head.S b/arch/arm/boot/compressed/head.S
+index fdd2e354ba3f..c5057234b014 100644
+--- a/arch/arm/boot/compressed/head.S
++++ b/arch/arm/boot/compressed/head.S
+@@ -114,7 +114,7 @@
+ #endif
+ 		.endm
+ 
+-		.section ".start", #alloc, #execinstr
++		.section ".start", "ax"
+ /*
+  * sort out different calling conventions
+  */
+diff --git a/arch/arm/boot/compressed/piggy.gzip.S b/arch/arm/boot/compressed/piggy.gzip.S
+index a68adf91a165..175ed02a6ac3 100644
+--- a/arch/arm/boot/compressed/piggy.gzip.S
++++ b/arch/arm/boot/compressed/piggy.gzip.S
+@@ -1,4 +1,4 @@
+-	.section .piggydata,#alloc
++	.section .piggydata, "a"
+ 	.globl	input_data
+ input_data:
+ 	.incbin	"arch/arm/boot/compressed/piggy.gzip"
+diff --git a/arch/arm/boot/compressed/piggy.lzma.S b/arch/arm/boot/compressed/piggy.lzma.S
+index d7e69cffbc0a..cfea81ae8f4b 100644
+--- a/arch/arm/boot/compressed/piggy.lzma.S
++++ b/arch/arm/boot/compressed/piggy.lzma.S
+@@ -1,4 +1,4 @@
+-	.section .piggydata,#alloc
++	.section .piggydata, "a"
+ 	.globl	input_data
+ input_data:
+ 	.incbin	"arch/arm/boot/compressed/piggy.lzma"
+diff --git a/arch/arm/boot/compressed/piggy.lzo.S b/arch/arm/boot/compressed/piggy.lzo.S
+index a425ad95959a..236976d8dc7d 100644
+--- a/arch/arm/boot/compressed/piggy.lzo.S
++++ b/arch/arm/boot/compressed/piggy.lzo.S
+@@ -1,4 +1,4 @@
+-	.section .piggydata,#alloc
++	.section .piggydata, "a"
+ 	.globl	input_data
+ input_data:
+ 	.incbin	"arch/arm/boot/compressed/piggy.lzo"
+diff --git a/arch/arm/boot/compressed/piggy.xzkern.S b/arch/arm/boot/compressed/piggy.xzkern.S
+index 5703f300d027..a135d3b549c5 100644
+--- a/arch/arm/boot/compressed/piggy.xzkern.S
++++ b/arch/arm/boot/compressed/piggy.xzkern.S
+@@ -1,4 +1,4 @@
+-	.section .piggydata,#alloc
++	.section .piggydata, "a"
+ 	.globl	input_data
+ input_data:
+ 	.incbin	"arch/arm/boot/compressed/piggy.xzkern"
+diff --git a/arch/arm/mm/proc-v7.S b/arch/arm/mm/proc-v7.S
+index 1f8597462b3a..050e3da34b9f 100644
+--- a/arch/arm/mm/proc-v7.S
++++ b/arch/arm/mm/proc-v7.S
+@@ -417,7 +417,7 @@ __v7_setup_stack:
+ 	string	cpu_elf_name, "v7"
+ 	.align
+ 
+-	.section ".proc.info.init", #alloc, #execinstr
++	.section ".proc.info.init", "ax"
+ 
+ 	/*
+ 	 * Standard v7 proc info content

--- a/meta-bass/recipes-kernel/linux/linux-bass_lp-mr1.bb
+++ b/meta-bass/recipes-kernel/linux/linux-bass_lp-mr1.bb
@@ -17,6 +17,7 @@ SRC_URI = "git://android.googlesource.com/kernel/msm;branch=android-msm-bass-3.1
     file://0006-ARM-uaccess-remove-put_user-code-duplication.patch \
     file://0007-random-introduce-getrandom-2-system-call.patch \
     file://0008-ARM-wire-up-getrandom-syscall.patch \
+    file://0009-ARM-8933-1-replace-Sun-Solaris-style-flag-on-section.patch \
     file://defconfig \
     file://img_info "
 SRCREV = "4bcdb1888f288bff5bed803dc79ee6a9121d71c7"

--- a/meta-catfish/recipes-kernel/linux/linux-catfish/0007-ARM-8933-1-replace-Sun-Solaris-style-flag-on-section.patch
+++ b/meta-catfish/recipes-kernel/linux/linux-catfish/0007-ARM-8933-1-replace-Sun-Solaris-style-flag-on-section.patch
@@ -1,0 +1,151 @@
+From d625236755ac4c6621cbaa618d5f21c9725207a8 Mon Sep 17 00:00:00 2001
+From: casept <davids.paskevics@gmail.com>
+Date: Sat, 15 Jun 2024 23:20:54 +0200
+Subject: [PATCH] ARM: 8933/1: replace Sun/Solaris style flag on section
+ directive
+
+It looks like a section directive was using "Solaris style" to declare
+the section flags. Replace this with the GNU style so that Clang's
+integrated assembler can assemble this directive.
+
+The modified instances were identified via:
+$ ag \.section | grep #
+
+Link: https://ftp.gnu.org/old-gnu/Manuals/gas-2.9.1/html_chapter/as_7.html#SEC119
+Link: https://github.com/ClangBuiltLinux/linux/issues/744
+Link: https://bugs.llvm.org/show_bug.cgi?id=43759
+Link: https://reviews.llvm.org/D69296
+
+Acked-by: Nicolas Pitre <nico@fluxnic.net>
+Reviewed-by: Ard Biesheuvel <ardb@kernel.org>
+Reviewed-by: Stefan Agner <stefan@agner.ch>
+Signed-off-by: Nick Desaulniers <ndesaulniers@google.com>
+Suggested-by: Fangrui Song <maskray@google.com>
+Suggested-by: Jian Cai <jiancai@google.com>
+Suggested-by: Peter Smith <peter.smith@linaro.org>
+Signed-off-by: Russell King <rmk+kernel@armlinux.org.uk>
+[ partial backport to 3.18 ]
+---
+ arch/arm/boot/bootp/init.S              | 2 +-
+ arch/arm/boot/compressed/big-endian.S   | 2 +-
+ arch/arm/boot/compressed/head.S         | 2 +-
+ arch/arm/boot/compressed/piggy.gzip.S   | 2 +-
+ arch/arm/boot/compressed/piggy.lz4.S    | 2 +-
+ arch/arm/boot/compressed/piggy.lzma.S   | 2 +-
+ arch/arm/boot/compressed/piggy.lzo.S    | 2 +-
+ arch/arm/boot/compressed/piggy.xzkern.S | 2 +-
+ arch/arm/boot/vmlinux                   | 1 +
+ arch/arm/mm/proc-v7.S                   | 2 +-
+ 10 files changed, 10 insertions(+), 9 deletions(-)
+ create mode 120000 arch/arm/boot/vmlinux
+
+diff --git a/arch/arm/boot/bootp/init.S b/arch/arm/boot/bootp/init.S
+index 78b508075161..868eeeaaa46e 100644
+--- a/arch/arm/boot/bootp/init.S
++++ b/arch/arm/boot/bootp/init.S
+@@ -16,7 +16,7 @@
+  *  size immediately following the kernel, we could build this into
+  *  a binary blob, and concatenate the zImage using the cat command.
+  */
+-		.section .start,#alloc,#execinstr
++		.section .start, "ax"
+ 		.type	_start, #function
+ 		.globl	_start
+ 
+diff --git a/arch/arm/boot/compressed/big-endian.S b/arch/arm/boot/compressed/big-endian.S
+index 25ab26f1c6f0..f22428e275f8 100644
+--- a/arch/arm/boot/compressed/big-endian.S
++++ b/arch/arm/boot/compressed/big-endian.S
+@@ -5,7 +5,7 @@
+  *  Author: Nicolas Pitre
+  */
+ 
+-	.section ".start", #alloc, #execinstr
++	.section ".start", "ax"
+ 
+ 	mrc	p15, 0, r0, c1, c0, 0	@ read control reg
+ 	orr	r0, r0, #(1 << 7)	@ enable big endian mode
+diff --git a/arch/arm/boot/compressed/head.S b/arch/arm/boot/compressed/head.S
+index 93ff12f1be6c..3b9386aeef7d 100644
+--- a/arch/arm/boot/compressed/head.S
++++ b/arch/arm/boot/compressed/head.S
+@@ -109,7 +109,7 @@
+ #endif
+ 		.endm
+ 
+-		.section ".start", #alloc, #execinstr
++		.section ".start", "ax"
+ /*
+  * sort out different calling conventions
+  */
+diff --git a/arch/arm/boot/compressed/piggy.gzip.S b/arch/arm/boot/compressed/piggy.gzip.S
+index a68adf91a165..175ed02a6ac3 100644
+--- a/arch/arm/boot/compressed/piggy.gzip.S
++++ b/arch/arm/boot/compressed/piggy.gzip.S
+@@ -1,4 +1,4 @@
+-	.section .piggydata,#alloc
++	.section .piggydata, "a"
+ 	.globl	input_data
+ input_data:
+ 	.incbin	"arch/arm/boot/compressed/piggy.gzip"
+diff --git a/arch/arm/boot/compressed/piggy.lz4.S b/arch/arm/boot/compressed/piggy.lz4.S
+index 3d9a575618a3..710f07de46ed 100644
+--- a/arch/arm/boot/compressed/piggy.lz4.S
++++ b/arch/arm/boot/compressed/piggy.lz4.S
+@@ -1,4 +1,4 @@
+-	.section .piggydata,#alloc
++	.section .piggydata, "a"
+ 	.globl	input_data
+ input_data:
+ 	.incbin	"arch/arm/boot/compressed/piggy.lz4"
+diff --git a/arch/arm/boot/compressed/piggy.lzma.S b/arch/arm/boot/compressed/piggy.lzma.S
+index d7e69cffbc0a..cfea81ae8f4b 100644
+--- a/arch/arm/boot/compressed/piggy.lzma.S
++++ b/arch/arm/boot/compressed/piggy.lzma.S
+@@ -1,4 +1,4 @@
+-	.section .piggydata,#alloc
++	.section .piggydata, "a"
+ 	.globl	input_data
+ input_data:
+ 	.incbin	"arch/arm/boot/compressed/piggy.lzma"
+diff --git a/arch/arm/boot/compressed/piggy.lzo.S b/arch/arm/boot/compressed/piggy.lzo.S
+index a425ad95959a..236976d8dc7d 100644
+--- a/arch/arm/boot/compressed/piggy.lzo.S
++++ b/arch/arm/boot/compressed/piggy.lzo.S
+@@ -1,4 +1,4 @@
+-	.section .piggydata,#alloc
++	.section .piggydata, "a"
+ 	.globl	input_data
+ input_data:
+ 	.incbin	"arch/arm/boot/compressed/piggy.lzo"
+diff --git a/arch/arm/boot/compressed/piggy.xzkern.S b/arch/arm/boot/compressed/piggy.xzkern.S
+index 5703f300d027..a135d3b549c5 100644
+--- a/arch/arm/boot/compressed/piggy.xzkern.S
++++ b/arch/arm/boot/compressed/piggy.xzkern.S
+@@ -1,4 +1,4 @@
+-	.section .piggydata,#alloc
++	.section .piggydata, "a"
+ 	.globl	input_data
+ input_data:
+ 	.incbin	"arch/arm/boot/compressed/piggy.xzkern"
+diff --git a/arch/arm/boot/vmlinux b/arch/arm/boot/vmlinux
+new file mode 120000
+index 000000000000..99da2949f171
+--- /dev/null
++++ b/arch/arm/boot/vmlinux
+@@ -0,0 +1 @@
++../../../vmlinux
+\ No newline at end of file
+diff --git a/arch/arm/mm/proc-v7.S b/arch/arm/mm/proc-v7.S
+index 984da460c758..3d3a81f6f780 100644
+--- a/arch/arm/mm/proc-v7.S
++++ b/arch/arm/mm/proc-v7.S
+@@ -462,7 +462,7 @@ __v7_setup_stack:
+ 	string	cpu_elf_name, "v7"
+ 	.align
+ 
+-	.section ".proc.info.init", #alloc
++	.section ".proc.info.init", "a"
+ 
+ 	/*
+ 	 * Standard v7 proc info content

--- a/meta-catfish/recipes-kernel/linux/linux-catfish/0007-ARM-8933-1-replace-Sun-Solaris-style-flag-on-section.patch
+++ b/meta-catfish/recipes-kernel/linux/linux-catfish/0007-ARM-8933-1-replace-Sun-Solaris-style-flag-on-section.patch
@@ -1,6 +1,6 @@
-From d625236755ac4c6621cbaa618d5f21c9725207a8 Mon Sep 17 00:00:00 2001
+From a20337182c194621d6e03750f1576f301bef88ea Mon Sep 17 00:00:00 2001
 From: casept <davids.paskevics@gmail.com>
-Date: Sat, 15 Jun 2024 23:20:54 +0200
+Date: Mon, 17 Jun 2024 00:19:01 +0200
 Subject: [PATCH] ARM: 8933/1: replace Sun/Solaris style flag on section
  directive
 
@@ -34,10 +34,8 @@ Signed-off-by: Russell King <rmk+kernel@armlinux.org.uk>
  arch/arm/boot/compressed/piggy.lzma.S   | 2 +-
  arch/arm/boot/compressed/piggy.lzo.S    | 2 +-
  arch/arm/boot/compressed/piggy.xzkern.S | 2 +-
- arch/arm/boot/vmlinux                   | 1 +
  arch/arm/mm/proc-v7.S                   | 2 +-
- 10 files changed, 10 insertions(+), 9 deletions(-)
- create mode 120000 arch/arm/boot/vmlinux
+ 9 files changed, 9 insertions(+), 9 deletions(-)
 
 diff --git a/arch/arm/boot/bootp/init.S b/arch/arm/boot/bootp/init.S
 index 78b508075161..868eeeaaa46e 100644
@@ -128,14 +126,6 @@ index 5703f300d027..a135d3b549c5 100644
  	.globl	input_data
  input_data:
  	.incbin	"arch/arm/boot/compressed/piggy.xzkern"
-diff --git a/arch/arm/boot/vmlinux b/arch/arm/boot/vmlinux
-new file mode 120000
-index 000000000000..99da2949f171
---- /dev/null
-+++ b/arch/arm/boot/vmlinux
-@@ -0,0 +1 @@
-+../../../vmlinux
-\ No newline at end of file
 diff --git a/arch/arm/mm/proc-v7.S b/arch/arm/mm/proc-v7.S
 index 984da460c758..3d3a81f6f780 100644
 --- a/arch/arm/mm/proc-v7.S

--- a/meta-catfish/recipes-kernel/linux/linux-catfish_p.bb
+++ b/meta-catfish/recipes-kernel/linux/linux-catfish_p.bb
@@ -8,16 +8,17 @@ LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://COPYING;md5=d7810fab7487fb0aad327b76f1be7cd7"
 COMPATIBLE_MACHINE = "catfish"
 
-SRC_URI = " git://android.googlesource.com/kernel/msm;branch=android-msm-catshark-3.18-pie-wear-dr;protocol=https \
-    file://defconfig \
-    file://img_info \
-    file://0001-scripts-dtc-Remove-redundant-YYLOC-global-declaratio.patch \
-    file://0002-usb-gadget-include-gadget-folder-to-fix-compilation.patch \
-    file://0003-char-bbd2.0-Fix-include-error.patch \
-    file://0004-Backport-mainline-4.1-Bluetooth-subsystem.patch \
-    file://0005-Focaltech-Delay-when-sending-wakeup-event.patch \
-    file://0006-dts-msm8909w-Enable-more-GPU-clock-frequencies.patch \
-"
+SRC_URI = "git://android.googlesource.com/kernel/msm;branch=android-msm-catshark-3.18-pie-wear-dr;protocol=https \
+           file://defconfig \
+           file://img_info \
+           file://0001-scripts-dtc-Remove-redundant-YYLOC-global-declaratio.patch \
+           file://0002-usb-gadget-include-gadget-folder-to-fix-compilation.patch \
+           file://0003-char-bbd2.0-Fix-include-error.patch \
+           file://0004-Backport-mainline-4.1-Bluetooth-subsystem.patch \
+           file://0005-Focaltech-Delay-when-sending-wakeup-event.patch \
+           file://0006-dts-msm8909w-Enable-more-GPU-clock-frequencies.patch \
+           file://0007-ARM-8933-1-replace-Sun-Solaris-style-flag-on-section.patch \
+           "
 
 SRCREV = "2b65638aaf038943506d1e6e7a942a4948490a42"
 LINUX_VERSION ?= "3.18"

--- a/meta-dory/recipes-kernel/linux/linux-dory/0010-ARM-8933-1-replace-Sun-Solaris-style-flag-on-section.patch
+++ b/meta-dory/recipes-kernel/linux/linux-dory/0010-ARM-8933-1-replace-Sun-Solaris-style-flag-on-section.patch
@@ -1,0 +1,116 @@
+From 52b7b0ea9d9e4672dfc742f71cc6b08a8d10ffa7 Mon Sep 17 00:00:00 2001
+From: casept <davids.paskevics@gmail.com>
+Date: Sun, 16 Jun 2024 00:51:52 +0200
+Subject: [PATCH] ARM: 8933/1: replace Sun/Solaris style flag on section
+ directive
+
+It looks like a section directive was using "Solaris style" to declare
+the section flags. Replace this with the GNU style so that Clang's
+integrated assembler can assemble this directive.
+
+The modified instances were identified via:
+$ ag \.section | grep #
+
+Link: https://ftp.gnu.org/old-gnu/Manuals/gas-2.9.1/html_chapter/as_7.html#SEC119
+Link: https://github.com/ClangBuiltLinux/linux/issues/744
+Link: https://bugs.llvm.org/show_bug.cgi?id=43759
+Link: https://reviews.llvm.org/D69296
+
+Acked-by: Nicolas Pitre <nico@fluxnic.net>
+Reviewed-by: Ard Biesheuvel <ardb@kernel.org>
+Reviewed-by: Stefan Agner <stefan@agner.ch>
+Signed-off-by: Nick Desaulniers <ndesaulniers@google.com>
+Suggested-by: Fangrui Song <maskray@google.com>
+Suggested-by: Jian Cai <jiancai@google.com>
+Suggested-by: Peter Smith <peter.smith@linaro.org>
+Signed-off-by: Russell King <rmk+kernel@armlinux.org.uk>
+[ partial backport to 3.10 ]
+---
+ arch/arm/boot/compressed/big-endian.S   | 2 +-
+ arch/arm/boot/compressed/head.S         | 2 +-
+ arch/arm/boot/compressed/piggy.gzip.S   | 2 +-
+ arch/arm/boot/compressed/piggy.lzma.S   | 2 +-
+ arch/arm/boot/compressed/piggy.lzo.S    | 2 +-
+ arch/arm/boot/compressed/piggy.xzkern.S | 2 +-
+ arch/arm/mm/proc-v7.S                   | 2 +-
+ 7 files changed, 7 insertions(+), 7 deletions(-)
+
+diff --git a/arch/arm/boot/compressed/big-endian.S b/arch/arm/boot/compressed/big-endian.S
+index 25ab26f1c6f0..f22428e275f8 100644
+--- a/arch/arm/boot/compressed/big-endian.S
++++ b/arch/arm/boot/compressed/big-endian.S
+@@ -5,7 +5,7 @@
+  *  Author: Nicolas Pitre
+  */
+ 
+-	.section ".start", #alloc, #execinstr
++	.section ".start", "ax"
+ 
+ 	mrc	p15, 0, r0, c1, c0, 0	@ read control reg
+ 	orr	r0, r0, #(1 << 7)	@ enable big endian mode
+diff --git a/arch/arm/boot/compressed/head.S b/arch/arm/boot/compressed/head.S
+index fdd2e354ba3f..c5057234b014 100644
+--- a/arch/arm/boot/compressed/head.S
++++ b/arch/arm/boot/compressed/head.S
+@@ -114,7 +114,7 @@
+ #endif
+ 		.endm
+ 
+-		.section ".start", #alloc, #execinstr
++		.section ".start", "ax"
+ /*
+  * sort out different calling conventions
+  */
+diff --git a/arch/arm/boot/compressed/piggy.gzip.S b/arch/arm/boot/compressed/piggy.gzip.S
+index a68adf91a165..175ed02a6ac3 100644
+--- a/arch/arm/boot/compressed/piggy.gzip.S
++++ b/arch/arm/boot/compressed/piggy.gzip.S
+@@ -1,4 +1,4 @@
+-	.section .piggydata,#alloc
++	.section .piggydata, "a"
+ 	.globl	input_data
+ input_data:
+ 	.incbin	"arch/arm/boot/compressed/piggy.gzip"
+diff --git a/arch/arm/boot/compressed/piggy.lzma.S b/arch/arm/boot/compressed/piggy.lzma.S
+index d7e69cffbc0a..cfea81ae8f4b 100644
+--- a/arch/arm/boot/compressed/piggy.lzma.S
++++ b/arch/arm/boot/compressed/piggy.lzma.S
+@@ -1,4 +1,4 @@
+-	.section .piggydata,#alloc
++	.section .piggydata, "a"
+ 	.globl	input_data
+ input_data:
+ 	.incbin	"arch/arm/boot/compressed/piggy.lzma"
+diff --git a/arch/arm/boot/compressed/piggy.lzo.S b/arch/arm/boot/compressed/piggy.lzo.S
+index a425ad95959a..236976d8dc7d 100644
+--- a/arch/arm/boot/compressed/piggy.lzo.S
++++ b/arch/arm/boot/compressed/piggy.lzo.S
+@@ -1,4 +1,4 @@
+-	.section .piggydata,#alloc
++	.section .piggydata, "a"
+ 	.globl	input_data
+ input_data:
+ 	.incbin	"arch/arm/boot/compressed/piggy.lzo"
+diff --git a/arch/arm/boot/compressed/piggy.xzkern.S b/arch/arm/boot/compressed/piggy.xzkern.S
+index 5703f300d027..a135d3b549c5 100644
+--- a/arch/arm/boot/compressed/piggy.xzkern.S
++++ b/arch/arm/boot/compressed/piggy.xzkern.S
+@@ -1,4 +1,4 @@
+-	.section .piggydata,#alloc
++	.section .piggydata, "a"
+ 	.globl	input_data
+ input_data:
+ 	.incbin	"arch/arm/boot/compressed/piggy.xzkern"
+diff --git a/arch/arm/mm/proc-v7.S b/arch/arm/mm/proc-v7.S
+index 1f8597462b3a..050e3da34b9f 100644
+--- a/arch/arm/mm/proc-v7.S
++++ b/arch/arm/mm/proc-v7.S
+@@ -417,7 +417,7 @@ __v7_setup_stack:
+ 	string	cpu_elf_name, "v7"
+ 	.align
+ 
+-	.section ".proc.info.init", #alloc, #execinstr
++	.section ".proc.info.init", "ax"
+ 
+ 	/*
+ 	 * Standard v7 proc info content

--- a/meta-dory/recipes-kernel/linux/linux-dory_mm.bb
+++ b/meta-dory/recipes-kernel/linux/linux-dory_mm.bb
@@ -20,6 +20,7 @@ SRC_URI = "git://android.googlesource.com/kernel/msm;branch=android-msm-dory-3.1
     file://0007-ARM-uaccess-remove-put_user-code-duplication.patch \
     file://0008-random-introduce-getrandom-2-system-call.patch \
     file://0009-ARM-wire-up-getrandom-syscall.patch \
+    file://0010-ARM-8933-1-replace-Sun-Solaris-style-flag-on-section.patch \
 "
 SRCREV = "6924014484d3406e3d2da384efc20e40e8a5ae80"
 LINUX_VERSION ?= "3.10"

--- a/meta-hoki/recipes-kernel/linux/linux-hoki/0001-ARM-8933-1-replace-Sun-Solaris-style-flag-on-section.patch
+++ b/meta-hoki/recipes-kernel/linux/linux-hoki/0001-ARM-8933-1-replace-Sun-Solaris-style-flag-on-section.patch
@@ -1,0 +1,98 @@
+From ace1f34bef2119c4db4336b64d0963c7211bc4a0 Mon Sep 17 00:00:00 2001
+From: casept <davids.paskevics@gmail.com>
+Date: Sun, 16 Jun 2024 04:17:46 +0200
+Subject: [PATCH] ARM: 8933/1: replace Sun/Solaris style flag on section
+ directive
+
+It looks like a section directive was using "Solaris style" to declare
+the section flags. Replace this with the GNU style so that Clang's
+integrated assembler can assemble this directive.
+
+The modified instances were identified via:
+$ ag \.section | grep #
+
+Link: https://ftp.gnu.org/old-gnu/Manuals/gas-2.9.1/html_chapter/as_7.html#SEC119
+Link: https://github.com/ClangBuiltLinux/linux/issues/744
+Link: https://bugs.llvm.org/show_bug.cgi?id=43759
+Link: https://reviews.llvm.org/D69296
+
+Acked-by: Nicolas Pitre <nico@fluxnic.net>
+Reviewed-by: Ard Biesheuvel <ardb@kernel.org>
+Reviewed-by: Stefan Agner <stefan@agner.ch>
+Signed-off-by: Nick Desaulniers <ndesaulniers@google.com>
+Suggested-by: Fangrui Song <maskray@google.com>
+Suggested-by: Jian Cai <jiancai@google.com>
+Suggested-by: Peter Smith <peter.smith@linaro.org>
+Signed-off-by: Russell King <rmk+kernel@armlinux.org.uk>
+[ partial backport to 4.4 ]
+---
+ arch/arm/boot/bootp/init.S            | 2 +-
+ arch/arm/boot/compressed/big-endian.S | 2 +-
+ arch/arm/boot/compressed/head.S       | 2 +-
+ arch/arm/boot/compressed/piggy.S      | 2 +-
+ arch/arm/mm/proc-v7.S                 | 2 +-
+ 5 files changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/arch/arm/boot/bootp/init.S b/arch/arm/boot/bootp/init.S
+index 78b508075161..868eeeaaa46e 100644
+--- a/arch/arm/boot/bootp/init.S
++++ b/arch/arm/boot/bootp/init.S
+@@ -16,7 +16,7 @@
+  *  size immediately following the kernel, we could build this into
+  *  a binary blob, and concatenate the zImage using the cat command.
+  */
+-		.section .start,#alloc,#execinstr
++		.section .start, "ax"
+ 		.type	_start, #function
+ 		.globl	_start
+ 
+diff --git a/arch/arm/boot/compressed/big-endian.S b/arch/arm/boot/compressed/big-endian.S
+index 88e2a88d324b..0e092c36da2f 100644
+--- a/arch/arm/boot/compressed/big-endian.S
++++ b/arch/arm/boot/compressed/big-endian.S
+@@ -6,7 +6,7 @@
+  *  Author: Nicolas Pitre
+  */
+ 
+-	.section ".start", #alloc, #execinstr
++	.section ".start", "ax"
+ 
+ 	mrc	p15, 0, r0, c1, c0, 0	@ read control reg
+ 	orr	r0, r0, #(1 << 7)	@ enable big endian mode
+diff --git a/arch/arm/boot/compressed/head.S b/arch/arm/boot/compressed/head.S
+index 11a65120987b..5304c87bf857 100644
+--- a/arch/arm/boot/compressed/head.S
++++ b/arch/arm/boot/compressed/head.S
+@@ -114,7 +114,7 @@
+ #endif
+ 		.endm
+ 
+-		.section ".start", #alloc, #execinstr
++		.section ".start", "ax"
+ /*
+  * sort out different calling conventions
+  */
+diff --git a/arch/arm/boot/compressed/piggy.S b/arch/arm/boot/compressed/piggy.S
+index 0284f84dcf38..27577644ee72 100644
+--- a/arch/arm/boot/compressed/piggy.S
++++ b/arch/arm/boot/compressed/piggy.S
+@@ -1,5 +1,5 @@
+ /* SPDX-License-Identifier: GPL-2.0 */
+-	.section .piggydata,#alloc
++	.section .piggydata, "a"
+ 	.globl	input_data
+ input_data:
+ 	.incbin	"arch/arm/boot/compressed/piggy_data"
+diff --git a/arch/arm/mm/proc-v7.S b/arch/arm/mm/proc-v7.S
+index b397cf1e486d..c9ecaa39980c 100644
+--- a/arch/arm/mm/proc-v7.S
++++ b/arch/arm/mm/proc-v7.S
+@@ -637,7 +637,7 @@ __v7_setup_stack:
+ 	string	cpu_elf_name, "v7"
+ 	.align
+ 
+-	.section ".proc.info.init", #alloc
++	.section ".proc.info.init", "a"
+ 
+ 	/*
+ 	 * Standard v7 proc info content

--- a/meta-hoki/recipes-kernel/linux/linux-hoki_p.bb
+++ b/meta-hoki/recipes-kernel/linux/linux-hoki_p.bb
@@ -8,15 +8,16 @@ LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://COPYING;md5=d7810fab7487fb0aad327b76f1be7cd7"
 COMPATIBLE_MACHINE = "hoki"
 
-SRC_URI = " git://github.com/fossil-engineering/kernel-msm-fossil-cw;branch=fossil-android-msm-hoki-lw1.2-4.14;protocol=https \
-    file://defconfig \
-    file://img_info \
-    file://0001-dts-Add-hoki-device-trees.patch \
-    file://0002-mmc-Fix-embedded_sdio_data-duplicate-definition.patch \
-    file://0003-video-fbdev-msm-Provide-mdss_dsi_switch_page.patch \
-    file://0004-usb-hcd-Handle-when-host-mode-isn-t-available.patch \
-    file://0005-initramfs-Don-t-skip-initramfs.patch \
-" 
+SRC_URI = "git://github.com/fossil-engineering/kernel-msm-fossil-cw;branch=fossil-android-msm-hoki-lw1.2-4.14;protocol=https \
+           file://defconfig \
+           file://img_info \
+           file://0001-dts-Add-hoki-device-trees.patch \
+           file://0002-mmc-Fix-embedded_sdio_data-duplicate-definition.patch \
+           file://0003-video-fbdev-msm-Provide-mdss_dsi_switch_page.patch \
+           file://0004-usb-hcd-Handle-when-host-mode-isn-t-available.patch \
+           file://0005-initramfs-Don-t-skip-initramfs.patch \
+           file://0001-ARM-8933-1-replace-Sun-Solaris-style-flag-on-section.patch \
+           "
 
 SRCREV = "c0b4c201f2d5a641defe19958a9b4c16f40d866b"
 LINUX_VERSION ?= "4.14"

--- a/meta-koi/recipes-kernel/linux/linux-koi/0006-ARM-8933-1-replace-Sun-Solaris-style-flag-on-section.patch
+++ b/meta-koi/recipes-kernel/linux/linux-koi/0006-ARM-8933-1-replace-Sun-Solaris-style-flag-on-section.patch
@@ -1,0 +1,141 @@
+From a20337182c194621d6e03750f1576f301bef88ea Mon Sep 17 00:00:00 2001
+From: casept <davids.paskevics@gmail.com>
+Date: Mon, 17 Jun 2024 00:19:01 +0200
+Subject: [PATCH] ARM: 8933/1: replace Sun/Solaris style flag on section
+ directive
+
+It looks like a section directive was using "Solaris style" to declare
+the section flags. Replace this with the GNU style so that Clang's
+integrated assembler can assemble this directive.
+
+The modified instances were identified via:
+$ ag \.section | grep #
+
+Link: https://ftp.gnu.org/old-gnu/Manuals/gas-2.9.1/html_chapter/as_7.html#SEC119
+Link: https://github.com/ClangBuiltLinux/linux/issues/744
+Link: https://bugs.llvm.org/show_bug.cgi?id=43759
+Link: https://reviews.llvm.org/D69296
+
+Acked-by: Nicolas Pitre <nico@fluxnic.net>
+Reviewed-by: Ard Biesheuvel <ardb@kernel.org>
+Reviewed-by: Stefan Agner <stefan@agner.ch>
+Signed-off-by: Nick Desaulniers <ndesaulniers@google.com>
+Suggested-by: Fangrui Song <maskray@google.com>
+Suggested-by: Jian Cai <jiancai@google.com>
+Suggested-by: Peter Smith <peter.smith@linaro.org>
+Signed-off-by: Russell King <rmk+kernel@armlinux.org.uk>
+[ partial backport to 3.18 ]
+---
+ arch/arm/boot/bootp/init.S              | 2 +-
+ arch/arm/boot/compressed/big-endian.S   | 2 +-
+ arch/arm/boot/compressed/head.S         | 2 +-
+ arch/arm/boot/compressed/piggy.gzip.S   | 2 +-
+ arch/arm/boot/compressed/piggy.lz4.S    | 2 +-
+ arch/arm/boot/compressed/piggy.lzma.S   | 2 +-
+ arch/arm/boot/compressed/piggy.lzo.S    | 2 +-
+ arch/arm/boot/compressed/piggy.xzkern.S | 2 +-
+ arch/arm/mm/proc-v7.S                   | 2 +-
+ 9 files changed, 9 insertions(+), 9 deletions(-)
+
+diff --git a/arch/arm/boot/bootp/init.S b/arch/arm/boot/bootp/init.S
+index 78b508075161..868eeeaaa46e 100644
+--- a/arch/arm/boot/bootp/init.S
++++ b/arch/arm/boot/bootp/init.S
+@@ -16,7 +16,7 @@
+  *  size immediately following the kernel, we could build this into
+  *  a binary blob, and concatenate the zImage using the cat command.
+  */
+-		.section .start,#alloc,#execinstr
++		.section .start, "ax"
+ 		.type	_start, #function
+ 		.globl	_start
+ 
+diff --git a/arch/arm/boot/compressed/big-endian.S b/arch/arm/boot/compressed/big-endian.S
+index 25ab26f1c6f0..f22428e275f8 100644
+--- a/arch/arm/boot/compressed/big-endian.S
++++ b/arch/arm/boot/compressed/big-endian.S
+@@ -5,7 +5,7 @@
+  *  Author: Nicolas Pitre
+  */
+ 
+-	.section ".start", #alloc, #execinstr
++	.section ".start", "ax"
+ 
+ 	mrc	p15, 0, r0, c1, c0, 0	@ read control reg
+ 	orr	r0, r0, #(1 << 7)	@ enable big endian mode
+diff --git a/arch/arm/boot/compressed/head.S b/arch/arm/boot/compressed/head.S
+index 93ff12f1be6c..3b9386aeef7d 100644
+--- a/arch/arm/boot/compressed/head.S
++++ b/arch/arm/boot/compressed/head.S
+@@ -109,7 +109,7 @@
+ #endif
+ 		.endm
+ 
+-		.section ".start", #alloc, #execinstr
++		.section ".start", "ax"
+ /*
+  * sort out different calling conventions
+  */
+diff --git a/arch/arm/boot/compressed/piggy.gzip.S b/arch/arm/boot/compressed/piggy.gzip.S
+index a68adf91a165..175ed02a6ac3 100644
+--- a/arch/arm/boot/compressed/piggy.gzip.S
++++ b/arch/arm/boot/compressed/piggy.gzip.S
+@@ -1,4 +1,4 @@
+-	.section .piggydata,#alloc
++	.section .piggydata, "a"
+ 	.globl	input_data
+ input_data:
+ 	.incbin	"arch/arm/boot/compressed/piggy.gzip"
+diff --git a/arch/arm/boot/compressed/piggy.lz4.S b/arch/arm/boot/compressed/piggy.lz4.S
+index 3d9a575618a3..710f07de46ed 100644
+--- a/arch/arm/boot/compressed/piggy.lz4.S
++++ b/arch/arm/boot/compressed/piggy.lz4.S
+@@ -1,4 +1,4 @@
+-	.section .piggydata,#alloc
++	.section .piggydata, "a"
+ 	.globl	input_data
+ input_data:
+ 	.incbin	"arch/arm/boot/compressed/piggy.lz4"
+diff --git a/arch/arm/boot/compressed/piggy.lzma.S b/arch/arm/boot/compressed/piggy.lzma.S
+index d7e69cffbc0a..cfea81ae8f4b 100644
+--- a/arch/arm/boot/compressed/piggy.lzma.S
++++ b/arch/arm/boot/compressed/piggy.lzma.S
+@@ -1,4 +1,4 @@
+-	.section .piggydata,#alloc
++	.section .piggydata, "a"
+ 	.globl	input_data
+ input_data:
+ 	.incbin	"arch/arm/boot/compressed/piggy.lzma"
+diff --git a/arch/arm/boot/compressed/piggy.lzo.S b/arch/arm/boot/compressed/piggy.lzo.S
+index a425ad95959a..236976d8dc7d 100644
+--- a/arch/arm/boot/compressed/piggy.lzo.S
++++ b/arch/arm/boot/compressed/piggy.lzo.S
+@@ -1,4 +1,4 @@
+-	.section .piggydata,#alloc
++	.section .piggydata, "a"
+ 	.globl	input_data
+ input_data:
+ 	.incbin	"arch/arm/boot/compressed/piggy.lzo"
+diff --git a/arch/arm/boot/compressed/piggy.xzkern.S b/arch/arm/boot/compressed/piggy.xzkern.S
+index 5703f300d027..a135d3b549c5 100644
+--- a/arch/arm/boot/compressed/piggy.xzkern.S
++++ b/arch/arm/boot/compressed/piggy.xzkern.S
+@@ -1,4 +1,4 @@
+-	.section .piggydata,#alloc
++	.section .piggydata, "a"
+ 	.globl	input_data
+ input_data:
+ 	.incbin	"arch/arm/boot/compressed/piggy.xzkern"
+diff --git a/arch/arm/mm/proc-v7.S b/arch/arm/mm/proc-v7.S
+index 984da460c758..3d3a81f6f780 100644
+--- a/arch/arm/mm/proc-v7.S
++++ b/arch/arm/mm/proc-v7.S
+@@ -462,7 +462,7 @@ __v7_setup_stack:
+ 	string	cpu_elf_name, "v7"
+ 	.align
+ 
+-	.section ".proc.info.init", #alloc
++	.section ".proc.info.init", "a"
+ 
+ 	/*
+ 	 * Standard v7 proc info content

--- a/meta-koi/recipes-kernel/linux/linux-koi_o.bb
+++ b/meta-koi/recipes-kernel/linux/linux-koi_o.bb
@@ -15,6 +15,7 @@ SRC_URI = " git://android.googlesource.com/kernel/exynos;branch=android-exynos-k
     file://0003-Fix-compilations-warnings.patch \
     file://0004-Backport-mainline-4.1-Bluetooth-subsystem.patch \
     file://0005-Backport-mainline-4.1-Bluetooth-drivers.patch \
+    file://0006-ARM-8933-1-replace-Sun-Solaris-style-flag-on-section.patch \
 "
 
 SRCREV = "f684256405854c40b5ccc2d126f810cf4c29ca2f"

--- a/meta-lenok/recipes-kernel/linux/linux-lenok/0010-ARM-8933-1-replace-Sun-Solaris-style-flag-on-section.patch
+++ b/meta-lenok/recipes-kernel/linux/linux-lenok/0010-ARM-8933-1-replace-Sun-Solaris-style-flag-on-section.patch
@@ -1,0 +1,116 @@
+From 52b7b0ea9d9e4672dfc742f71cc6b08a8d10ffa7 Mon Sep 17 00:00:00 2001
+From: casept <davids.paskevics@gmail.com>
+Date: Sun, 16 Jun 2024 00:51:52 +0200
+Subject: [PATCH] ARM: 8933/1: replace Sun/Solaris style flag on section
+ directive
+
+It looks like a section directive was using "Solaris style" to declare
+the section flags. Replace this with the GNU style so that Clang's
+integrated assembler can assemble this directive.
+
+The modified instances were identified via:
+$ ag \.section | grep #
+
+Link: https://ftp.gnu.org/old-gnu/Manuals/gas-2.9.1/html_chapter/as_7.html#SEC119
+Link: https://github.com/ClangBuiltLinux/linux/issues/744
+Link: https://bugs.llvm.org/show_bug.cgi?id=43759
+Link: https://reviews.llvm.org/D69296
+
+Acked-by: Nicolas Pitre <nico@fluxnic.net>
+Reviewed-by: Ard Biesheuvel <ardb@kernel.org>
+Reviewed-by: Stefan Agner <stefan@agner.ch>
+Signed-off-by: Nick Desaulniers <ndesaulniers@google.com>
+Suggested-by: Fangrui Song <maskray@google.com>
+Suggested-by: Jian Cai <jiancai@google.com>
+Suggested-by: Peter Smith <peter.smith@linaro.org>
+Signed-off-by: Russell King <rmk+kernel@armlinux.org.uk>
+[ partial backport to 3.10 ]
+---
+ arch/arm/boot/compressed/big-endian.S   | 2 +-
+ arch/arm/boot/compressed/head.S         | 2 +-
+ arch/arm/boot/compressed/piggy.gzip.S   | 2 +-
+ arch/arm/boot/compressed/piggy.lzma.S   | 2 +-
+ arch/arm/boot/compressed/piggy.lzo.S    | 2 +-
+ arch/arm/boot/compressed/piggy.xzkern.S | 2 +-
+ arch/arm/mm/proc-v7.S                   | 2 +-
+ 7 files changed, 7 insertions(+), 7 deletions(-)
+
+diff --git a/arch/arm/boot/compressed/big-endian.S b/arch/arm/boot/compressed/big-endian.S
+index 25ab26f1c6f0..f22428e275f8 100644
+--- a/arch/arm/boot/compressed/big-endian.S
++++ b/arch/arm/boot/compressed/big-endian.S
+@@ -5,7 +5,7 @@
+  *  Author: Nicolas Pitre
+  */
+ 
+-	.section ".start", #alloc, #execinstr
++	.section ".start", "ax"
+ 
+ 	mrc	p15, 0, r0, c1, c0, 0	@ read control reg
+ 	orr	r0, r0, #(1 << 7)	@ enable big endian mode
+diff --git a/arch/arm/boot/compressed/head.S b/arch/arm/boot/compressed/head.S
+index fdd2e354ba3f..c5057234b014 100644
+--- a/arch/arm/boot/compressed/head.S
++++ b/arch/arm/boot/compressed/head.S
+@@ -114,7 +114,7 @@
+ #endif
+ 		.endm
+ 
+-		.section ".start", #alloc, #execinstr
++		.section ".start", "ax"
+ /*
+  * sort out different calling conventions
+  */
+diff --git a/arch/arm/boot/compressed/piggy.gzip.S b/arch/arm/boot/compressed/piggy.gzip.S
+index a68adf91a165..175ed02a6ac3 100644
+--- a/arch/arm/boot/compressed/piggy.gzip.S
++++ b/arch/arm/boot/compressed/piggy.gzip.S
+@@ -1,4 +1,4 @@
+-	.section .piggydata,#alloc
++	.section .piggydata, "a"
+ 	.globl	input_data
+ input_data:
+ 	.incbin	"arch/arm/boot/compressed/piggy.gzip"
+diff --git a/arch/arm/boot/compressed/piggy.lzma.S b/arch/arm/boot/compressed/piggy.lzma.S
+index d7e69cffbc0a..cfea81ae8f4b 100644
+--- a/arch/arm/boot/compressed/piggy.lzma.S
++++ b/arch/arm/boot/compressed/piggy.lzma.S
+@@ -1,4 +1,4 @@
+-	.section .piggydata,#alloc
++	.section .piggydata, "a"
+ 	.globl	input_data
+ input_data:
+ 	.incbin	"arch/arm/boot/compressed/piggy.lzma"
+diff --git a/arch/arm/boot/compressed/piggy.lzo.S b/arch/arm/boot/compressed/piggy.lzo.S
+index a425ad95959a..236976d8dc7d 100644
+--- a/arch/arm/boot/compressed/piggy.lzo.S
++++ b/arch/arm/boot/compressed/piggy.lzo.S
+@@ -1,4 +1,4 @@
+-	.section .piggydata,#alloc
++	.section .piggydata, "a"
+ 	.globl	input_data
+ input_data:
+ 	.incbin	"arch/arm/boot/compressed/piggy.lzo"
+diff --git a/arch/arm/boot/compressed/piggy.xzkern.S b/arch/arm/boot/compressed/piggy.xzkern.S
+index 5703f300d027..a135d3b549c5 100644
+--- a/arch/arm/boot/compressed/piggy.xzkern.S
++++ b/arch/arm/boot/compressed/piggy.xzkern.S
+@@ -1,4 +1,4 @@
+-	.section .piggydata,#alloc
++	.section .piggydata, "a"
+ 	.globl	input_data
+ input_data:
+ 	.incbin	"arch/arm/boot/compressed/piggy.xzkern"
+diff --git a/arch/arm/mm/proc-v7.S b/arch/arm/mm/proc-v7.S
+index 1f8597462b3a..050e3da34b9f 100644
+--- a/arch/arm/mm/proc-v7.S
++++ b/arch/arm/mm/proc-v7.S
+@@ -417,7 +417,7 @@ __v7_setup_stack:
+ 	string	cpu_elf_name, "v7"
+ 	.align
+ 
+-	.section ".proc.info.init", #alloc, #execinstr
++	.section ".proc.info.init", "ax"
+ 
+ 	/*
+ 	 * Standard v7 proc info content

--- a/meta-lenok/recipes-kernel/linux/linux-lenok_mm-mr1.bb
+++ b/meta-lenok/recipes-kernel/linux/linux-lenok_mm-mr1.bb
@@ -18,6 +18,7 @@ SRC_URI = "git://android.googlesource.com/kernel/msm;branch=android-msm-lenok-3.
            file://0007-ARM-uaccess-remove-put_user-code-duplication.patch \
            file://0008-random-introduce-getrandom-2-system-call.patch \
            file://0009-ARM-wire-up-getrandom-syscall.patch \
+           file://0010-ARM-8933-1-replace-Sun-Solaris-style-flag-on-section.patch \
            file://defconfig \
            file://img_info \
            "

--- a/meta-minnow/recipes-kernel/linux/linux-minnow/0009-ARM-8933-1-replace-Sun-Solaris-style-flag-on-section.patch
+++ b/meta-minnow/recipes-kernel/linux/linux-minnow/0009-ARM-8933-1-replace-Sun-Solaris-style-flag-on-section.patch
@@ -1,0 +1,116 @@
+From 52b7b0ea9d9e4672dfc742f71cc6b08a8d10ffa7 Mon Sep 17 00:00:00 2001
+From: casept <davids.paskevics@gmail.com>
+Date: Sun, 16 Jun 2024 00:51:52 +0200
+Subject: [PATCH] ARM: 8933/1: replace Sun/Solaris style flag on section
+ directive
+
+It looks like a section directive was using "Solaris style" to declare
+the section flags. Replace this with the GNU style so that Clang's
+integrated assembler can assemble this directive.
+
+The modified instances were identified via:
+$ ag \.section | grep #
+
+Link: https://ftp.gnu.org/old-gnu/Manuals/gas-2.9.1/html_chapter/as_7.html#SEC119
+Link: https://github.com/ClangBuiltLinux/linux/issues/744
+Link: https://bugs.llvm.org/show_bug.cgi?id=43759
+Link: https://reviews.llvm.org/D69296
+
+Acked-by: Nicolas Pitre <nico@fluxnic.net>
+Reviewed-by: Ard Biesheuvel <ardb@kernel.org>
+Reviewed-by: Stefan Agner <stefan@agner.ch>
+Signed-off-by: Nick Desaulniers <ndesaulniers@google.com>
+Suggested-by: Fangrui Song <maskray@google.com>
+Suggested-by: Jian Cai <jiancai@google.com>
+Suggested-by: Peter Smith <peter.smith@linaro.org>
+Signed-off-by: Russell King <rmk+kernel@armlinux.org.uk>
+[ partial backport to 3.10 ]
+---
+ arch/arm/boot/compressed/big-endian.S   | 2 +-
+ arch/arm/boot/compressed/head.S         | 2 +-
+ arch/arm/boot/compressed/piggy.gzip.S   | 2 +-
+ arch/arm/boot/compressed/piggy.lzma.S   | 2 +-
+ arch/arm/boot/compressed/piggy.lzo.S    | 2 +-
+ arch/arm/boot/compressed/piggy.xzkern.S | 2 +-
+ arch/arm/mm/proc-v7.S                   | 2 +-
+ 7 files changed, 7 insertions(+), 7 deletions(-)
+
+diff --git a/arch/arm/boot/compressed/big-endian.S b/arch/arm/boot/compressed/big-endian.S
+index 25ab26f1c6f0..f22428e275f8 100644
+--- a/arch/arm/boot/compressed/big-endian.S
++++ b/arch/arm/boot/compressed/big-endian.S
+@@ -5,7 +5,7 @@
+  *  Author: Nicolas Pitre
+  */
+ 
+-	.section ".start", #alloc, #execinstr
++	.section ".start", "ax"
+ 
+ 	mrc	p15, 0, r0, c1, c0, 0	@ read control reg
+ 	orr	r0, r0, #(1 << 7)	@ enable big endian mode
+diff --git a/arch/arm/boot/compressed/head.S b/arch/arm/boot/compressed/head.S
+index fdd2e354ba3f..c5057234b014 100644
+--- a/arch/arm/boot/compressed/head.S
++++ b/arch/arm/boot/compressed/head.S
+@@ -114,7 +114,7 @@
+ #endif
+ 		.endm
+ 
+-		.section ".start", #alloc, #execinstr
++		.section ".start", "ax"
+ /*
+  * sort out different calling conventions
+  */
+diff --git a/arch/arm/boot/compressed/piggy.gzip.S b/arch/arm/boot/compressed/piggy.gzip.S
+index a68adf91a165..175ed02a6ac3 100644
+--- a/arch/arm/boot/compressed/piggy.gzip.S
++++ b/arch/arm/boot/compressed/piggy.gzip.S
+@@ -1,4 +1,4 @@
+-	.section .piggydata,#alloc
++	.section .piggydata, "a"
+ 	.globl	input_data
+ input_data:
+ 	.incbin	"arch/arm/boot/compressed/piggy.gzip"
+diff --git a/arch/arm/boot/compressed/piggy.lzma.S b/arch/arm/boot/compressed/piggy.lzma.S
+index d7e69cffbc0a..cfea81ae8f4b 100644
+--- a/arch/arm/boot/compressed/piggy.lzma.S
++++ b/arch/arm/boot/compressed/piggy.lzma.S
+@@ -1,4 +1,4 @@
+-	.section .piggydata,#alloc
++	.section .piggydata, "a"
+ 	.globl	input_data
+ input_data:
+ 	.incbin	"arch/arm/boot/compressed/piggy.lzma"
+diff --git a/arch/arm/boot/compressed/piggy.lzo.S b/arch/arm/boot/compressed/piggy.lzo.S
+index a425ad95959a..236976d8dc7d 100644
+--- a/arch/arm/boot/compressed/piggy.lzo.S
++++ b/arch/arm/boot/compressed/piggy.lzo.S
+@@ -1,4 +1,4 @@
+-	.section .piggydata,#alloc
++	.section .piggydata, "a"
+ 	.globl	input_data
+ input_data:
+ 	.incbin	"arch/arm/boot/compressed/piggy.lzo"
+diff --git a/arch/arm/boot/compressed/piggy.xzkern.S b/arch/arm/boot/compressed/piggy.xzkern.S
+index 5703f300d027..a135d3b549c5 100644
+--- a/arch/arm/boot/compressed/piggy.xzkern.S
++++ b/arch/arm/boot/compressed/piggy.xzkern.S
+@@ -1,4 +1,4 @@
+-	.section .piggydata,#alloc
++	.section .piggydata, "a"
+ 	.globl	input_data
+ input_data:
+ 	.incbin	"arch/arm/boot/compressed/piggy.xzkern"
+diff --git a/arch/arm/mm/proc-v7.S b/arch/arm/mm/proc-v7.S
+index 1f8597462b3a..050e3da34b9f 100644
+--- a/arch/arm/mm/proc-v7.S
++++ b/arch/arm/mm/proc-v7.S
+@@ -417,7 +417,7 @@ __v7_setup_stack:
+ 	string	cpu_elf_name, "v7"
+ 	.align
+ 
+-	.section ".proc.info.init", #alloc, #execinstr
++	.section ".proc.info.init", "ax"
+ 
+ 	/*
+ 	 * Standard v7 proc info content

--- a/meta-minnow/recipes-kernel/linux/linux-minnow_mm-mr1.bb
+++ b/meta-minnow/recipes-kernel/linux/linux-minnow_mm-mr1.bb
@@ -17,6 +17,7 @@ SRC_URI = " git://android.googlesource.com/kernel/omap;branch=android-omap-minno
     file://0006-ARM-uaccess-remove-put_user-code-duplication.patch \
     file://0007-random-introduce-getrandom-2-system-call.patch \
     file://0008-ARM-wire-up-getrandom-syscall.patch \
+    file://0009-ARM-8933-1-replace-Sun-Solaris-style-flag-on-section.patch \
     file://defconfig \
     file://img_info \
 "

--- a/meta-mooneye/recipes-kernel/linux/linux-mooneye/0008-ARM-8933-1-replace-Sun-Solaris-style-flag-on-section.patch
+++ b/meta-mooneye/recipes-kernel/linux/linux-mooneye/0008-ARM-8933-1-replace-Sun-Solaris-style-flag-on-section.patch
@@ -1,0 +1,141 @@
+From 67c9105b8a2fd8c4ac16835bfcddbc95d4241305 Mon Sep 17 00:00:00 2001
+From: casept <davids.paskevics@gmail.com>
+Date: Tue, 18 Jun 2024 09:55:07 +0200
+Subject: [PATCH] ARM: 8933/1: replace Sun/Solaris style flag on section
+ directive
+
+It looks like a section directive was using "Solaris style" to declare
+the section flags. Replace this with the GNU style so that Clang's
+integrated assembler can assemble this directive.
+
+The modified instances were identified via:
+$ ag \.section | grep #
+
+Link: https://ftp.gnu.org/old-gnu/Manuals/gas-2.9.1/html_chapter/as_7.html#SEC119
+Link: https://github.com/ClangBuiltLinux/linux/issues/744
+Link: https://bugs.llvm.org/show_bug.cgi?id=43759
+Link: https://reviews.llvm.org/D69296
+
+Acked-by: Nicolas Pitre <nico@fluxnic.net>
+Reviewed-by: Ard Biesheuvel <ardb@kernel.org>
+Reviewed-by: Stefan Agner <stefan@agner.ch>
+Signed-off-by: Nick Desaulniers <ndesaulniers@google.com>
+Suggested-by: Fangrui Song <maskray@google.com>
+Suggested-by: Jian Cai <jiancai@google.com>
+Suggested-by: Peter Smith <peter.smith@linaro.org>
+Signed-off-by: Russell King <rmk+kernel@armlinux.org.uk>
+[ partial backport to 4.4 ]
+---
+ arch/arm/boot/bootp/init.S              | 2 +-
+ arch/arm/boot/compressed/big-endian.S   | 2 +-
+ arch/arm/boot/compressed/head.S         | 2 +-
+ arch/arm/boot/compressed/piggy.gzip.S   | 2 +-
+ arch/arm/boot/compressed/piggy.lz4.S    | 2 +-
+ arch/arm/boot/compressed/piggy.lzma.S   | 2 +-
+ arch/arm/boot/compressed/piggy.lzo.S    | 2 +-
+ arch/arm/boot/compressed/piggy.xzkern.S | 2 +-
+ arch/arm/mm/proc-v7.S                   | 2 +-
+ 9 files changed, 9 insertions(+), 9 deletions(-)
+
+diff --git a/arch/arm/boot/bootp/init.S b/arch/arm/boot/bootp/init.S
+index 78b508075161..868eeeaaa46e 100644
+--- a/arch/arm/boot/bootp/init.S
++++ b/arch/arm/boot/bootp/init.S
+@@ -16,7 +16,7 @@
+  *  size immediately following the kernel, we could build this into
+  *  a binary blob, and concatenate the zImage using the cat command.
+  */
+-		.section .start,#alloc,#execinstr
++		.section .start, "ax"
+ 		.type	_start, #function
+ 		.globl	_start
+ 
+diff --git a/arch/arm/boot/compressed/big-endian.S b/arch/arm/boot/compressed/big-endian.S
+index 25ab26f1c6f0..f22428e275f8 100644
+--- a/arch/arm/boot/compressed/big-endian.S
++++ b/arch/arm/boot/compressed/big-endian.S
+@@ -5,7 +5,7 @@
+  *  Author: Nicolas Pitre
+  */
+ 
+-	.section ".start", #alloc, #execinstr
++	.section ".start", "ax"
+ 
+ 	mrc	p15, 0, r0, c1, c0, 0	@ read control reg
+ 	orr	r0, r0, #(1 << 7)	@ enable big endian mode
+diff --git a/arch/arm/boot/compressed/head.S b/arch/arm/boot/compressed/head.S
+index d2e43b053d9b..fc847bc77e6f 100644
+--- a/arch/arm/boot/compressed/head.S
++++ b/arch/arm/boot/compressed/head.S
+@@ -112,7 +112,7 @@
+ #endif
+ 		.endm
+ 
+-		.section ".start", #alloc, #execinstr
++		.section ".start", "ax"
+ /*
+  * sort out different calling conventions
+  */
+diff --git a/arch/arm/boot/compressed/piggy.gzip.S b/arch/arm/boot/compressed/piggy.gzip.S
+index a68adf91a165..175ed02a6ac3 100644
+--- a/arch/arm/boot/compressed/piggy.gzip.S
++++ b/arch/arm/boot/compressed/piggy.gzip.S
+@@ -1,4 +1,4 @@
+-	.section .piggydata,#alloc
++	.section .piggydata, "a"
+ 	.globl	input_data
+ input_data:
+ 	.incbin	"arch/arm/boot/compressed/piggy.gzip"
+diff --git a/arch/arm/boot/compressed/piggy.lz4.S b/arch/arm/boot/compressed/piggy.lz4.S
+index 3d9a575618a3..710f07de46ed 100644
+--- a/arch/arm/boot/compressed/piggy.lz4.S
++++ b/arch/arm/boot/compressed/piggy.lz4.S
+@@ -1,4 +1,4 @@
+-	.section .piggydata,#alloc
++	.section .piggydata, "a"
+ 	.globl	input_data
+ input_data:
+ 	.incbin	"arch/arm/boot/compressed/piggy.lz4"
+diff --git a/arch/arm/boot/compressed/piggy.lzma.S b/arch/arm/boot/compressed/piggy.lzma.S
+index d7e69cffbc0a..cfea81ae8f4b 100644
+--- a/arch/arm/boot/compressed/piggy.lzma.S
++++ b/arch/arm/boot/compressed/piggy.lzma.S
+@@ -1,4 +1,4 @@
+-	.section .piggydata,#alloc
++	.section .piggydata, "a"
+ 	.globl	input_data
+ input_data:
+ 	.incbin	"arch/arm/boot/compressed/piggy.lzma"
+diff --git a/arch/arm/boot/compressed/piggy.lzo.S b/arch/arm/boot/compressed/piggy.lzo.S
+index a425ad95959a..236976d8dc7d 100644
+--- a/arch/arm/boot/compressed/piggy.lzo.S
++++ b/arch/arm/boot/compressed/piggy.lzo.S
+@@ -1,4 +1,4 @@
+-	.section .piggydata,#alloc
++	.section .piggydata, "a"
+ 	.globl	input_data
+ input_data:
+ 	.incbin	"arch/arm/boot/compressed/piggy.lzo"
+diff --git a/arch/arm/boot/compressed/piggy.xzkern.S b/arch/arm/boot/compressed/piggy.xzkern.S
+index 5703f300d027..a135d3b549c5 100644
+--- a/arch/arm/boot/compressed/piggy.xzkern.S
++++ b/arch/arm/boot/compressed/piggy.xzkern.S
+@@ -1,4 +1,4 @@
+-	.section .piggydata,#alloc
++	.section .piggydata, "a"
+ 	.globl	input_data
+ input_data:
+ 	.incbin	"arch/arm/boot/compressed/piggy.xzkern"
+diff --git a/arch/arm/mm/proc-v7.S b/arch/arm/mm/proc-v7.S
+index 8e1ea433c3f1..e2536a3d5da5 100644
+--- a/arch/arm/mm/proc-v7.S
++++ b/arch/arm/mm/proc-v7.S
+@@ -504,7 +504,7 @@ __v7_setup_stack:
+ 	string	cpu_elf_name, "v7"
+ 	.align
+ 
+-	.section ".proc.info.init", #alloc
++	.section ".proc.info.init", "a"
+ 
+ 	/*
+ 	 * Standard v7 proc info content

--- a/meta-mooneye/recipes-kernel/linux/linux-mooneye_o.bb
+++ b/meta-mooneye/recipes-kernel/linux/linux-mooneye_o.bb
@@ -11,6 +11,8 @@ COMPATIBLE_MACHINE = "mooneye"
 # Use an older version of gcc (gcc >= 9 doesn't boot.)
 DEPENDS:remove = "virtual/${TARGET_PREFIX}gcc"
 DEPENDS += "virtual/${TARGET_PREFIX}gcc8"
+# Ancient GCC doesn't support this flag
+DEBUG_PREFIX_MAP:remove = "-fcanon-prefix-map"
 
 SRC_URI = "git://android.googlesource.com/kernel/mediatek;branch=android-mediatek-mooneye-4.4-oreo-wear-dr;protocol=https \
     file://0001-Fix-various-drivers-compilation-with-a-recent-GCC.patch \

--- a/meta-mooneye/recipes-kernel/linux/linux-mooneye_o.bb
+++ b/meta-mooneye/recipes-kernel/linux/linux-mooneye_o.bb
@@ -15,14 +15,16 @@ DEPENDS += "virtual/${TARGET_PREFIX}gcc8"
 DEBUG_PREFIX_MAP:remove = "-fcanon-prefix-map"
 
 SRC_URI = "git://android.googlesource.com/kernel/mediatek;branch=android-mediatek-mooneye-4.4-oreo-wear-dr;protocol=https \
-    file://0001-Fix-various-drivers-compilation-with-a-recent-GCC.patch \
-    file://0003-ARM-uaccess-remove-put_user-code-duplication.patch \
-    file://0004-Backport-HCI_STP-from-Mediatek.patch \
-    file://0005-hci-don-t-set-MWS-command.patch \
-    file://0006-hci_core-handle-incorrect-specified-max-page-number.patch \
-    file://0007-platform_uart-Avoid-a-kernel-panic-when-restoring-an.patch \
-    file://defconfig \
-    file://img_info"
+           file://0001-Fix-various-drivers-compilation-with-a-recent-GCC.patch \
+           file://0003-ARM-uaccess-remove-put_user-code-duplication.patch \
+           file://0004-Backport-HCI_STP-from-Mediatek.patch \
+           file://0005-hci-don-t-set-MWS-command.patch \
+           file://0006-hci_core-handle-incorrect-specified-max-page-number.patch \
+           file://0007-platform_uart-Avoid-a-kernel-panic-when-restoring-an.patch \
+           file://0008-ARM-8933-1-replace-Sun-Solaris-style-flag-on-section.patch \
+           file://defconfig \
+           file://img_info \
+           "
 SRCREV = "faeb8c03bca6c09f8817f4d509e0280b53af8b99"
 LINUX_VERSION ?= "4.4"
 PV = "${LINUX_VERSION}+oreo"

--- a/meta-mtk6580/recipes-kernel/linux/linux-harmony/0014-ARM-8933-1-replace-Sun-Solaris-style-flag-on-section.patch
+++ b/meta-mtk6580/recipes-kernel/linux/linux-harmony/0014-ARM-8933-1-replace-Sun-Solaris-style-flag-on-section.patch
@@ -1,0 +1,116 @@
+From 52b7b0ea9d9e4672dfc742f71cc6b08a8d10ffa7 Mon Sep 17 00:00:00 2001
+From: casept <davids.paskevics@gmail.com>
+Date: Sun, 16 Jun 2024 00:51:52 +0200
+Subject: [PATCH] ARM: 8933/1: replace Sun/Solaris style flag on section
+ directive
+
+It looks like a section directive was using "Solaris style" to declare
+the section flags. Replace this with the GNU style so that Clang's
+integrated assembler can assemble this directive.
+
+The modified instances were identified via:
+$ ag \.section | grep #
+
+Link: https://ftp.gnu.org/old-gnu/Manuals/gas-2.9.1/html_chapter/as_7.html#SEC119
+Link: https://github.com/ClangBuiltLinux/linux/issues/744
+Link: https://bugs.llvm.org/show_bug.cgi?id=43759
+Link: https://reviews.llvm.org/D69296
+
+Acked-by: Nicolas Pitre <nico@fluxnic.net>
+Reviewed-by: Ard Biesheuvel <ardb@kernel.org>
+Reviewed-by: Stefan Agner <stefan@agner.ch>
+Signed-off-by: Nick Desaulniers <ndesaulniers@google.com>
+Suggested-by: Fangrui Song <maskray@google.com>
+Suggested-by: Jian Cai <jiancai@google.com>
+Suggested-by: Peter Smith <peter.smith@linaro.org>
+Signed-off-by: Russell King <rmk+kernel@armlinux.org.uk>
+[ partial backport to 3.10 ]
+---
+ arch/arm/boot/compressed/big-endian.S   | 2 +-
+ arch/arm/boot/compressed/head.S         | 2 +-
+ arch/arm/boot/compressed/piggy.gzip.S   | 2 +-
+ arch/arm/boot/compressed/piggy.lzma.S   | 2 +-
+ arch/arm/boot/compressed/piggy.lzo.S    | 2 +-
+ arch/arm/boot/compressed/piggy.xzkern.S | 2 +-
+ arch/arm/mm/proc-v7.S                   | 2 +-
+ 7 files changed, 7 insertions(+), 7 deletions(-)
+
+diff --git a/arch/arm/boot/compressed/big-endian.S b/arch/arm/boot/compressed/big-endian.S
+index 25ab26f1c6f0..f22428e275f8 100644
+--- a/arch/arm/boot/compressed/big-endian.S
++++ b/arch/arm/boot/compressed/big-endian.S
+@@ -5,7 +5,7 @@
+  *  Author: Nicolas Pitre
+  */
+ 
+-	.section ".start", #alloc, #execinstr
++	.section ".start", "ax"
+ 
+ 	mrc	p15, 0, r0, c1, c0, 0	@ read control reg
+ 	orr	r0, r0, #(1 << 7)	@ enable big endian mode
+diff --git a/arch/arm/boot/compressed/head.S b/arch/arm/boot/compressed/head.S
+index fdd2e354ba3f..c5057234b014 100644
+--- a/arch/arm/boot/compressed/head.S
++++ b/arch/arm/boot/compressed/head.S
+@@ -114,7 +114,7 @@
+ #endif
+ 		.endm
+ 
+-		.section ".start", #alloc, #execinstr
++		.section ".start", "ax"
+ /*
+  * sort out different calling conventions
+  */
+diff --git a/arch/arm/boot/compressed/piggy.gzip.S b/arch/arm/boot/compressed/piggy.gzip.S
+index a68adf91a165..175ed02a6ac3 100644
+--- a/arch/arm/boot/compressed/piggy.gzip.S
++++ b/arch/arm/boot/compressed/piggy.gzip.S
+@@ -1,4 +1,4 @@
+-	.section .piggydata,#alloc
++	.section .piggydata, "a"
+ 	.globl	input_data
+ input_data:
+ 	.incbin	"arch/arm/boot/compressed/piggy.gzip"
+diff --git a/arch/arm/boot/compressed/piggy.lzma.S b/arch/arm/boot/compressed/piggy.lzma.S
+index d7e69cffbc0a..cfea81ae8f4b 100644
+--- a/arch/arm/boot/compressed/piggy.lzma.S
++++ b/arch/arm/boot/compressed/piggy.lzma.S
+@@ -1,4 +1,4 @@
+-	.section .piggydata,#alloc
++	.section .piggydata, "a"
+ 	.globl	input_data
+ input_data:
+ 	.incbin	"arch/arm/boot/compressed/piggy.lzma"
+diff --git a/arch/arm/boot/compressed/piggy.lzo.S b/arch/arm/boot/compressed/piggy.lzo.S
+index a425ad95959a..236976d8dc7d 100644
+--- a/arch/arm/boot/compressed/piggy.lzo.S
++++ b/arch/arm/boot/compressed/piggy.lzo.S
+@@ -1,4 +1,4 @@
+-	.section .piggydata,#alloc
++	.section .piggydata, "a"
+ 	.globl	input_data
+ input_data:
+ 	.incbin	"arch/arm/boot/compressed/piggy.lzo"
+diff --git a/arch/arm/boot/compressed/piggy.xzkern.S b/arch/arm/boot/compressed/piggy.xzkern.S
+index 5703f300d027..a135d3b549c5 100644
+--- a/arch/arm/boot/compressed/piggy.xzkern.S
++++ b/arch/arm/boot/compressed/piggy.xzkern.S
+@@ -1,4 +1,4 @@
+-	.section .piggydata,#alloc
++	.section .piggydata, "a"
+ 	.globl	input_data
+ input_data:
+ 	.incbin	"arch/arm/boot/compressed/piggy.xzkern"
+diff --git a/arch/arm/mm/proc-v7.S b/arch/arm/mm/proc-v7.S
+index 1f8597462b3a..050e3da34b9f 100644
+--- a/arch/arm/mm/proc-v7.S
++++ b/arch/arm/mm/proc-v7.S
+@@ -417,7 +417,7 @@ __v7_setup_stack:
+ 	string	cpu_elf_name, "v7"
+ 	.align
+ 
+-	.section ".proc.info.init", #alloc, #execinstr
++	.section ".proc.info.init", "ax"
+ 
+ 	/*
+ 	 * Standard v7 proc info content

--- a/meta-mtk6580/recipes-kernel/linux/linux-harmony/0015-Don-t-make-int-to-pointer-cast-warning-fail-compilat.patch
+++ b/meta-mtk6580/recipes-kernel/linux/linux-harmony/0015-Don-t-make-int-to-pointer-cast-warning-fail-compilat.patch
@@ -1,0 +1,26 @@
+From fa55d589eecb270c144087848a239d92f82a4fef Mon Sep 17 00:00:00 2001
+From: casept <davids.paskevics@gmail.com>
+Date: Sun, 16 Jun 2024 03:33:02 +0200
+Subject: [PATCH] Don't make int-to-pointer-cast warning fail compilation
+
+Newer compilers seem to detect this in spots older ones
+didn't, causing build failures. As the risk of introducing
+bugs is probably greater with an incorrect fix than letting
+it be, simply disable the warning.
+---
+ Makefile | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Makefile b/Makefile
+index 97a78af6..9fc0039c 100644
+--- a/Makefile
++++ b/Makefile
+@@ -374,7 +374,7 @@ KBUILD_CFLAGS   := -Wall -Wundef -Wstrict-prototypes -Wno-trigraphs \
+ 		   -Werror-implicit-function-declaration \
+ 		   -Wno-format-security \
+ 		   -fno-delete-null-pointer-checks \
+-		   -Werror=format -Werror=int-to-pointer-cast -Werror=pointer-to-int-cast
++		   -Werror=format -Werror=pointer-to-int-cast
+ 
+ KBUILD_AFLAGS_KERNEL :=
+ KBUILD_CFLAGS_KERNEL :=

--- a/meta-mtk6580/recipes-kernel/linux/linux-harmony_lp-mr1.bb
+++ b/meta-mtk6580/recipes-kernel/linux/linux-harmony_lp-mr1.bb
@@ -24,6 +24,7 @@ SRC_URI = "git://github.com/OpenWatchProject/android_kernel_mediatek_mt6580;prot
     file://0012-Disable-new-gcc-7.1.1-warnings.patch \
     file://0013-ARM-uaccess-remove-put_user-code-duplication.patch \
     file://0014-ARM-8933-1-replace-Sun-Solaris-style-flag-on-section.patch \
+    file://0015-Don-t-make-int-to-pointer-cast-warning-fail-compilat.patch \
     "
 SRC_URI:append:inharmony = "file://inharmonyconfig"
 

--- a/meta-mtk6580/recipes-kernel/linux/linux-harmony_lp-mr1.bb
+++ b/meta-mtk6580/recipes-kernel/linux/linux-harmony_lp-mr1.bb
@@ -23,6 +23,7 @@ SRC_URI = "git://github.com/OpenWatchProject/android_kernel_mediatek_mt6580;prot
     file://0011-sec_dev-Fix-firmware-loading.patch \
     file://0012-Disable-new-gcc-7.1.1-warnings.patch \
     file://0013-ARM-uaccess-remove-put_user-code-duplication.patch \
+    file://0014-ARM-8933-1-replace-Sun-Solaris-style-flag-on-section.patch \
     "
 SRC_URI:append:inharmony = "file://inharmonyconfig"
 

--- a/meta-narwhal/recipes-kernel/linux/files/0006-ARM-8933-1-replace-Sun-Solaris-style-flag-on-section.patch
+++ b/meta-narwhal/recipes-kernel/linux/files/0006-ARM-8933-1-replace-Sun-Solaris-style-flag-on-section.patch
@@ -1,6 +1,6 @@
-From a20337182c194621d6e03750f1576f301bef88ea Mon Sep 17 00:00:00 2001
+From cf48dda1e97d5428d8ae7a98220b1f8783ade88d Mon Sep 17 00:00:00 2001
 From: casept <davids.paskevics@gmail.com>
-Date: Mon, 17 Jun 2024 00:19:01 +0200
+Date: Tue, 18 Jun 2024 11:23:02 +0200
 Subject: [PATCH] ARM: 8933/1: replace Sun/Solaris style flag on section
  directive
 
@@ -64,7 +64,7 @@ index 25ab26f1c6f0..f22428e275f8 100644
  	mrc	p15, 0, r0, c1, c0, 0	@ read control reg
  	orr	r0, r0, #(1 << 7)	@ enable big endian mode
 diff --git a/arch/arm/boot/compressed/head.S b/arch/arm/boot/compressed/head.S
-index 93ff12f1be6c..3b9386aeef7d 100644
+index e9e0284fc8f2..ec0e837eecb2 100644
 --- a/arch/arm/boot/compressed/head.S
 +++ b/arch/arm/boot/compressed/head.S
 @@ -109,7 +109,7 @@
@@ -127,15 +127,15 @@ index 5703f300d027..a135d3b549c5 100644
  input_data:
  	.incbin	"arch/arm/boot/compressed/piggy.xzkern"
 diff --git a/arch/arm/mm/proc-v7.S b/arch/arm/mm/proc-v7.S
-index 984da460c758..3d3a81f6f780 100644
+index 22ac2a6fbfe3..68744e1c3643 100644
 --- a/arch/arm/mm/proc-v7.S
 +++ b/arch/arm/mm/proc-v7.S
 @@ -462,7 +462,7 @@ __v7_setup_stack:
  	string	cpu_elf_name, "v7"
  	.align
  
--	.section ".proc.info.init", #alloc
-+	.section ".proc.info.init", "a"
+-	.section ".proc.info.init", #alloc, #execinstr
++	.section ".proc.info.init", "ax"
  
  	/*
  	 * Standard v7 proc info content

--- a/meta-narwhal/recipes-kernel/linux/files/0006-ARM-8933-1-replace-Sun-Solaris-style-flag-on-section.patch
+++ b/meta-narwhal/recipes-kernel/linux/files/0006-ARM-8933-1-replace-Sun-Solaris-style-flag-on-section.patch
@@ -1,0 +1,141 @@
+From a20337182c194621d6e03750f1576f301bef88ea Mon Sep 17 00:00:00 2001
+From: casept <davids.paskevics@gmail.com>
+Date: Mon, 17 Jun 2024 00:19:01 +0200
+Subject: [PATCH] ARM: 8933/1: replace Sun/Solaris style flag on section
+ directive
+
+It looks like a section directive was using "Solaris style" to declare
+the section flags. Replace this with the GNU style so that Clang's
+integrated assembler can assemble this directive.
+
+The modified instances were identified via:
+$ ag \.section | grep #
+
+Link: https://ftp.gnu.org/old-gnu/Manuals/gas-2.9.1/html_chapter/as_7.html#SEC119
+Link: https://github.com/ClangBuiltLinux/linux/issues/744
+Link: https://bugs.llvm.org/show_bug.cgi?id=43759
+Link: https://reviews.llvm.org/D69296
+
+Acked-by: Nicolas Pitre <nico@fluxnic.net>
+Reviewed-by: Ard Biesheuvel <ardb@kernel.org>
+Reviewed-by: Stefan Agner <stefan@agner.ch>
+Signed-off-by: Nick Desaulniers <ndesaulniers@google.com>
+Suggested-by: Fangrui Song <maskray@google.com>
+Suggested-by: Jian Cai <jiancai@google.com>
+Suggested-by: Peter Smith <peter.smith@linaro.org>
+Signed-off-by: Russell King <rmk+kernel@armlinux.org.uk>
+[ partial backport to 3.18 ]
+---
+ arch/arm/boot/bootp/init.S              | 2 +-
+ arch/arm/boot/compressed/big-endian.S   | 2 +-
+ arch/arm/boot/compressed/head.S         | 2 +-
+ arch/arm/boot/compressed/piggy.gzip.S   | 2 +-
+ arch/arm/boot/compressed/piggy.lz4.S    | 2 +-
+ arch/arm/boot/compressed/piggy.lzma.S   | 2 +-
+ arch/arm/boot/compressed/piggy.lzo.S    | 2 +-
+ arch/arm/boot/compressed/piggy.xzkern.S | 2 +-
+ arch/arm/mm/proc-v7.S                   | 2 +-
+ 9 files changed, 9 insertions(+), 9 deletions(-)
+
+diff --git a/arch/arm/boot/bootp/init.S b/arch/arm/boot/bootp/init.S
+index 78b508075161..868eeeaaa46e 100644
+--- a/arch/arm/boot/bootp/init.S
++++ b/arch/arm/boot/bootp/init.S
+@@ -16,7 +16,7 @@
+  *  size immediately following the kernel, we could build this into
+  *  a binary blob, and concatenate the zImage using the cat command.
+  */
+-		.section .start,#alloc,#execinstr
++		.section .start, "ax"
+ 		.type	_start, #function
+ 		.globl	_start
+ 
+diff --git a/arch/arm/boot/compressed/big-endian.S b/arch/arm/boot/compressed/big-endian.S
+index 25ab26f1c6f0..f22428e275f8 100644
+--- a/arch/arm/boot/compressed/big-endian.S
++++ b/arch/arm/boot/compressed/big-endian.S
+@@ -5,7 +5,7 @@
+  *  Author: Nicolas Pitre
+  */
+ 
+-	.section ".start", #alloc, #execinstr
++	.section ".start", "ax"
+ 
+ 	mrc	p15, 0, r0, c1, c0, 0	@ read control reg
+ 	orr	r0, r0, #(1 << 7)	@ enable big endian mode
+diff --git a/arch/arm/boot/compressed/head.S b/arch/arm/boot/compressed/head.S
+index 93ff12f1be6c..3b9386aeef7d 100644
+--- a/arch/arm/boot/compressed/head.S
++++ b/arch/arm/boot/compressed/head.S
+@@ -109,7 +109,7 @@
+ #endif
+ 		.endm
+ 
+-		.section ".start", #alloc, #execinstr
++		.section ".start", "ax"
+ /*
+  * sort out different calling conventions
+  */
+diff --git a/arch/arm/boot/compressed/piggy.gzip.S b/arch/arm/boot/compressed/piggy.gzip.S
+index a68adf91a165..175ed02a6ac3 100644
+--- a/arch/arm/boot/compressed/piggy.gzip.S
++++ b/arch/arm/boot/compressed/piggy.gzip.S
+@@ -1,4 +1,4 @@
+-	.section .piggydata,#alloc
++	.section .piggydata, "a"
+ 	.globl	input_data
+ input_data:
+ 	.incbin	"arch/arm/boot/compressed/piggy.gzip"
+diff --git a/arch/arm/boot/compressed/piggy.lz4.S b/arch/arm/boot/compressed/piggy.lz4.S
+index 3d9a575618a3..710f07de46ed 100644
+--- a/arch/arm/boot/compressed/piggy.lz4.S
++++ b/arch/arm/boot/compressed/piggy.lz4.S
+@@ -1,4 +1,4 @@
+-	.section .piggydata,#alloc
++	.section .piggydata, "a"
+ 	.globl	input_data
+ input_data:
+ 	.incbin	"arch/arm/boot/compressed/piggy.lz4"
+diff --git a/arch/arm/boot/compressed/piggy.lzma.S b/arch/arm/boot/compressed/piggy.lzma.S
+index d7e69cffbc0a..cfea81ae8f4b 100644
+--- a/arch/arm/boot/compressed/piggy.lzma.S
++++ b/arch/arm/boot/compressed/piggy.lzma.S
+@@ -1,4 +1,4 @@
+-	.section .piggydata,#alloc
++	.section .piggydata, "a"
+ 	.globl	input_data
+ input_data:
+ 	.incbin	"arch/arm/boot/compressed/piggy.lzma"
+diff --git a/arch/arm/boot/compressed/piggy.lzo.S b/arch/arm/boot/compressed/piggy.lzo.S
+index a425ad95959a..236976d8dc7d 100644
+--- a/arch/arm/boot/compressed/piggy.lzo.S
++++ b/arch/arm/boot/compressed/piggy.lzo.S
+@@ -1,4 +1,4 @@
+-	.section .piggydata,#alloc
++	.section .piggydata, "a"
+ 	.globl	input_data
+ input_data:
+ 	.incbin	"arch/arm/boot/compressed/piggy.lzo"
+diff --git a/arch/arm/boot/compressed/piggy.xzkern.S b/arch/arm/boot/compressed/piggy.xzkern.S
+index 5703f300d027..a135d3b549c5 100644
+--- a/arch/arm/boot/compressed/piggy.xzkern.S
++++ b/arch/arm/boot/compressed/piggy.xzkern.S
+@@ -1,4 +1,4 @@
+-	.section .piggydata,#alloc
++	.section .piggydata, "a"
+ 	.globl	input_data
+ input_data:
+ 	.incbin	"arch/arm/boot/compressed/piggy.xzkern"
+diff --git a/arch/arm/mm/proc-v7.S b/arch/arm/mm/proc-v7.S
+index 984da460c758..3d3a81f6f780 100644
+--- a/arch/arm/mm/proc-v7.S
++++ b/arch/arm/mm/proc-v7.S
+@@ -462,7 +462,7 @@ __v7_setup_stack:
+ 	string	cpu_elf_name, "v7"
+ 	.align
+ 
+-	.section ".proc.info.init", #alloc
++	.section ".proc.info.init", "a"
+ 
+ 	/*
+ 	 * Standard v7 proc info content

--- a/meta-narwhal/recipes-kernel/linux/linux-narwhal_n.bb
+++ b/meta-narwhal/recipes-kernel/linux/linux-narwhal_n.bb
@@ -8,15 +8,16 @@ LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://COPYING;md5=d7810fab7487fb0aad327b76f1be7cd7"
 COMPATIBLE_MACHINE = "narwhal"
 
-SRC_URI = " git://android.googlesource.com/kernel/msm;branch=android-msm-narwhal-3.18-oreo-wear-dr;protocol=https \
-    file://defconfig \
-    file://img_info \
-    file://0001-scripts-dtc-Remove-redundant-YYLOC-global-declaratio.patch \
-    file://0002-ARM-uaccess-remove-put_user-code-duplication.patch \
-    file://0003-Backport-mainline-4.1-Bluetooth-subsystem.patch \
-    file://0004-Backport-mainline-4.1-Bluetooth-drivers.patch \
-    file://0005-video-mdp3-Continue-when-the-overlay-wasn-t-released.patch \
-"
+SRC_URI = "git://android.googlesource.com/kernel/msm;branch=android-msm-narwhal-3.18-oreo-wear-dr;protocol=https \
+           file://defconfig \
+           file://img_info \
+           file://0001-scripts-dtc-Remove-redundant-YYLOC-global-declaratio.patch \
+           file://0002-ARM-uaccess-remove-put_user-code-duplication.patch \
+           file://0003-Backport-mainline-4.1-Bluetooth-subsystem.patch \
+           file://0004-Backport-mainline-4.1-Bluetooth-drivers.patch \
+           file://0005-video-mdp3-Continue-when-the-overlay-wasn-t-released.patch \
+           file://0006-ARM-8933-1-replace-Sun-Solaris-style-flag-on-section.patch \
+           "
 
 SRCREV = "ef2880c313e30d5b99e138599fd3d81d90daae3e"
 LINUX_VERSION ?= "3.18"

--- a/meta-nemo/recipes-kernel/linux/linux-nemo/0007-ARM-8933-1-replace-Sun-Solaris-style-flag-on-section.patch
+++ b/meta-nemo/recipes-kernel/linux/linux-nemo/0007-ARM-8933-1-replace-Sun-Solaris-style-flag-on-section.patch
@@ -1,0 +1,116 @@
+From 52b7b0ea9d9e4672dfc742f71cc6b08a8d10ffa7 Mon Sep 17 00:00:00 2001
+From: casept <davids.paskevics@gmail.com>
+Date: Sun, 16 Jun 2024 00:51:52 +0200
+Subject: [PATCH] ARM: 8933/1: replace Sun/Solaris style flag on section
+ directive
+
+It looks like a section directive was using "Solaris style" to declare
+the section flags. Replace this with the GNU style so that Clang's
+integrated assembler can assemble this directive.
+
+The modified instances were identified via:
+$ ag \.section | grep #
+
+Link: https://ftp.gnu.org/old-gnu/Manuals/gas-2.9.1/html_chapter/as_7.html#SEC119
+Link: https://github.com/ClangBuiltLinux/linux/issues/744
+Link: https://bugs.llvm.org/show_bug.cgi?id=43759
+Link: https://reviews.llvm.org/D69296
+
+Acked-by: Nicolas Pitre <nico@fluxnic.net>
+Reviewed-by: Ard Biesheuvel <ardb@kernel.org>
+Reviewed-by: Stefan Agner <stefan@agner.ch>
+Signed-off-by: Nick Desaulniers <ndesaulniers@google.com>
+Suggested-by: Fangrui Song <maskray@google.com>
+Suggested-by: Jian Cai <jiancai@google.com>
+Suggested-by: Peter Smith <peter.smith@linaro.org>
+Signed-off-by: Russell King <rmk+kernel@armlinux.org.uk>
+[ partial backport to 3.10 ]
+---
+ arch/arm/boot/compressed/big-endian.S   | 2 +-
+ arch/arm/boot/compressed/head.S         | 2 +-
+ arch/arm/boot/compressed/piggy.gzip.S   | 2 +-
+ arch/arm/boot/compressed/piggy.lzma.S   | 2 +-
+ arch/arm/boot/compressed/piggy.lzo.S    | 2 +-
+ arch/arm/boot/compressed/piggy.xzkern.S | 2 +-
+ arch/arm/mm/proc-v7.S                   | 2 +-
+ 7 files changed, 7 insertions(+), 7 deletions(-)
+
+diff --git a/arch/arm/boot/compressed/big-endian.S b/arch/arm/boot/compressed/big-endian.S
+index 25ab26f1c6f0..f22428e275f8 100644
+--- a/arch/arm/boot/compressed/big-endian.S
++++ b/arch/arm/boot/compressed/big-endian.S
+@@ -5,7 +5,7 @@
+  *  Author: Nicolas Pitre
+  */
+ 
+-	.section ".start", #alloc, #execinstr
++	.section ".start", "ax"
+ 
+ 	mrc	p15, 0, r0, c1, c0, 0	@ read control reg
+ 	orr	r0, r0, #(1 << 7)	@ enable big endian mode
+diff --git a/arch/arm/boot/compressed/head.S b/arch/arm/boot/compressed/head.S
+index fdd2e354ba3f..c5057234b014 100644
+--- a/arch/arm/boot/compressed/head.S
++++ b/arch/arm/boot/compressed/head.S
+@@ -114,7 +114,7 @@
+ #endif
+ 		.endm
+ 
+-		.section ".start", #alloc, #execinstr
++		.section ".start", "ax"
+ /*
+  * sort out different calling conventions
+  */
+diff --git a/arch/arm/boot/compressed/piggy.gzip.S b/arch/arm/boot/compressed/piggy.gzip.S
+index a68adf91a165..175ed02a6ac3 100644
+--- a/arch/arm/boot/compressed/piggy.gzip.S
++++ b/arch/arm/boot/compressed/piggy.gzip.S
+@@ -1,4 +1,4 @@
+-	.section .piggydata,#alloc
++	.section .piggydata, "a"
+ 	.globl	input_data
+ input_data:
+ 	.incbin	"arch/arm/boot/compressed/piggy.gzip"
+diff --git a/arch/arm/boot/compressed/piggy.lzma.S b/arch/arm/boot/compressed/piggy.lzma.S
+index d7e69cffbc0a..cfea81ae8f4b 100644
+--- a/arch/arm/boot/compressed/piggy.lzma.S
++++ b/arch/arm/boot/compressed/piggy.lzma.S
+@@ -1,4 +1,4 @@
+-	.section .piggydata,#alloc
++	.section .piggydata, "a"
+ 	.globl	input_data
+ input_data:
+ 	.incbin	"arch/arm/boot/compressed/piggy.lzma"
+diff --git a/arch/arm/boot/compressed/piggy.lzo.S b/arch/arm/boot/compressed/piggy.lzo.S
+index a425ad95959a..236976d8dc7d 100644
+--- a/arch/arm/boot/compressed/piggy.lzo.S
++++ b/arch/arm/boot/compressed/piggy.lzo.S
+@@ -1,4 +1,4 @@
+-	.section .piggydata,#alloc
++	.section .piggydata, "a"
+ 	.globl	input_data
+ input_data:
+ 	.incbin	"arch/arm/boot/compressed/piggy.lzo"
+diff --git a/arch/arm/boot/compressed/piggy.xzkern.S b/arch/arm/boot/compressed/piggy.xzkern.S
+index 5703f300d027..a135d3b549c5 100644
+--- a/arch/arm/boot/compressed/piggy.xzkern.S
++++ b/arch/arm/boot/compressed/piggy.xzkern.S
+@@ -1,4 +1,4 @@
+-	.section .piggydata,#alloc
++	.section .piggydata, "a"
+ 	.globl	input_data
+ input_data:
+ 	.incbin	"arch/arm/boot/compressed/piggy.xzkern"
+diff --git a/arch/arm/mm/proc-v7.S b/arch/arm/mm/proc-v7.S
+index 1f8597462b3a..050e3da34b9f 100644
+--- a/arch/arm/mm/proc-v7.S
++++ b/arch/arm/mm/proc-v7.S
+@@ -417,7 +417,7 @@ __v7_setup_stack:
+ 	string	cpu_elf_name, "v7"
+ 	.align
+ 
+-	.section ".proc.info.init", #alloc, #execinstr
++	.section ".proc.info.init", "ax"
+ 
+ 	/*
+ 	 * Standard v7 proc info content

--- a/meta-nemo/recipes-kernel/linux/linux-nemo_lp-mr1.bb
+++ b/meta-nemo/recipes-kernel/linux/linux-nemo_lp-mr1.bb
@@ -12,6 +12,7 @@ SRC_URI = "git://android.googlesource.com/kernel/msm;branch=android-msm-nemo-3.1
     file://0001-scripts-dtc-Remove-redundant-YYLOC-global-declaratio.patch \
     file://0002-static-inline-in-ARM-ftrace.h.patch;striplevel=1 \
     file://0006-ARM-uaccess-remove-put_user-code-duplication.patch \
+    file://0007-ARM-8933-1-replace-Sun-Solaris-style-flag-on-section.patch \
     file://defconfig \
     file://img_info "
 SRCREV = "504f3357f3ef296bf5ccbfe05df2025fa41eb354"

--- a/meta-pike/recipes-kernel/linux/linux-pike/0006-ARM-8933-1-replace-Sun-Solaris-style-flag-on-section.patch
+++ b/meta-pike/recipes-kernel/linux/linux-pike/0006-ARM-8933-1-replace-Sun-Solaris-style-flag-on-section.patch
@@ -1,0 +1,116 @@
+From 52b7b0ea9d9e4672dfc742f71cc6b08a8d10ffa7 Mon Sep 17 00:00:00 2001
+From: casept <davids.paskevics@gmail.com>
+Date: Sun, 16 Jun 2024 00:51:52 +0200
+Subject: [PATCH] ARM: 8933/1: replace Sun/Solaris style flag on section
+ directive
+
+It looks like a section directive was using "Solaris style" to declare
+the section flags. Replace this with the GNU style so that Clang's
+integrated assembler can assemble this directive.
+
+The modified instances were identified via:
+$ ag \.section | grep #
+
+Link: https://ftp.gnu.org/old-gnu/Manuals/gas-2.9.1/html_chapter/as_7.html#SEC119
+Link: https://github.com/ClangBuiltLinux/linux/issues/744
+Link: https://bugs.llvm.org/show_bug.cgi?id=43759
+Link: https://reviews.llvm.org/D69296
+
+Acked-by: Nicolas Pitre <nico@fluxnic.net>
+Reviewed-by: Ard Biesheuvel <ardb@kernel.org>
+Reviewed-by: Stefan Agner <stefan@agner.ch>
+Signed-off-by: Nick Desaulniers <ndesaulniers@google.com>
+Suggested-by: Fangrui Song <maskray@google.com>
+Suggested-by: Jian Cai <jiancai@google.com>
+Suggested-by: Peter Smith <peter.smith@linaro.org>
+Signed-off-by: Russell King <rmk+kernel@armlinux.org.uk>
+[ partial backport to 3.10 ]
+---
+ arch/arm/boot/compressed/big-endian.S   | 2 +-
+ arch/arm/boot/compressed/head.S         | 2 +-
+ arch/arm/boot/compressed/piggy.gzip.S   | 2 +-
+ arch/arm/boot/compressed/piggy.lzma.S   | 2 +-
+ arch/arm/boot/compressed/piggy.lzo.S    | 2 +-
+ arch/arm/boot/compressed/piggy.xzkern.S | 2 +-
+ arch/arm/mm/proc-v7.S                   | 2 +-
+ 7 files changed, 7 insertions(+), 7 deletions(-)
+
+diff --git a/arch/arm/boot/compressed/big-endian.S b/arch/arm/boot/compressed/big-endian.S
+index 25ab26f1c6f0..f22428e275f8 100644
+--- a/arch/arm/boot/compressed/big-endian.S
++++ b/arch/arm/boot/compressed/big-endian.S
+@@ -5,7 +5,7 @@
+  *  Author: Nicolas Pitre
+  */
+ 
+-	.section ".start", #alloc, #execinstr
++	.section ".start", "ax"
+ 
+ 	mrc	p15, 0, r0, c1, c0, 0	@ read control reg
+ 	orr	r0, r0, #(1 << 7)	@ enable big endian mode
+diff --git a/arch/arm/boot/compressed/head.S b/arch/arm/boot/compressed/head.S
+index fdd2e354ba3f..c5057234b014 100644
+--- a/arch/arm/boot/compressed/head.S
++++ b/arch/arm/boot/compressed/head.S
+@@ -114,7 +114,7 @@
+ #endif
+ 		.endm
+ 
+-		.section ".start", #alloc, #execinstr
++		.section ".start", "ax"
+ /*
+  * sort out different calling conventions
+  */
+diff --git a/arch/arm/boot/compressed/piggy.gzip.S b/arch/arm/boot/compressed/piggy.gzip.S
+index a68adf91a165..175ed02a6ac3 100644
+--- a/arch/arm/boot/compressed/piggy.gzip.S
++++ b/arch/arm/boot/compressed/piggy.gzip.S
+@@ -1,4 +1,4 @@
+-	.section .piggydata,#alloc
++	.section .piggydata, "a"
+ 	.globl	input_data
+ input_data:
+ 	.incbin	"arch/arm/boot/compressed/piggy.gzip"
+diff --git a/arch/arm/boot/compressed/piggy.lzma.S b/arch/arm/boot/compressed/piggy.lzma.S
+index d7e69cffbc0a..cfea81ae8f4b 100644
+--- a/arch/arm/boot/compressed/piggy.lzma.S
++++ b/arch/arm/boot/compressed/piggy.lzma.S
+@@ -1,4 +1,4 @@
+-	.section .piggydata,#alloc
++	.section .piggydata, "a"
+ 	.globl	input_data
+ input_data:
+ 	.incbin	"arch/arm/boot/compressed/piggy.lzma"
+diff --git a/arch/arm/boot/compressed/piggy.lzo.S b/arch/arm/boot/compressed/piggy.lzo.S
+index a425ad95959a..236976d8dc7d 100644
+--- a/arch/arm/boot/compressed/piggy.lzo.S
++++ b/arch/arm/boot/compressed/piggy.lzo.S
+@@ -1,4 +1,4 @@
+-	.section .piggydata,#alloc
++	.section .piggydata, "a"
+ 	.globl	input_data
+ input_data:
+ 	.incbin	"arch/arm/boot/compressed/piggy.lzo"
+diff --git a/arch/arm/boot/compressed/piggy.xzkern.S b/arch/arm/boot/compressed/piggy.xzkern.S
+index 5703f300d027..a135d3b549c5 100644
+--- a/arch/arm/boot/compressed/piggy.xzkern.S
++++ b/arch/arm/boot/compressed/piggy.xzkern.S
+@@ -1,4 +1,4 @@
+-	.section .piggydata,#alloc
++	.section .piggydata, "a"
+ 	.globl	input_data
+ input_data:
+ 	.incbin	"arch/arm/boot/compressed/piggy.xzkern"
+diff --git a/arch/arm/mm/proc-v7.S b/arch/arm/mm/proc-v7.S
+index 1f8597462b3a..050e3da34b9f 100644
+--- a/arch/arm/mm/proc-v7.S
++++ b/arch/arm/mm/proc-v7.S
+@@ -417,7 +417,7 @@ __v7_setup_stack:
+ 	string	cpu_elf_name, "v7"
+ 	.align
+ 
+-	.section ".proc.info.init", #alloc, #execinstr
++	.section ".proc.info.init", "ax"
+ 
+ 	/*
+ 	 * Standard v7 proc info content

--- a/meta-pike/recipes-kernel/linux/linux-pike_o.bb
+++ b/meta-pike/recipes-kernel/linux/linux-pike_o.bb
@@ -11,6 +11,8 @@ COMPATIBLE_MACHINE = "pike"
 # Use an older version of gcc (gcc >= 9 doesn't boot.)
 DEPENDS:remove = "virtual/${TARGET_PREFIX}gcc"
 DEPENDS += "virtual/${TARGET_PREFIX}gcc8"
+# Ancient GCC doesn't support this flag
+DEBUG_PREFIX_MAP:remove = "-fcanon-prefix-map"
 
 SRC_URI = "git://android.googlesource.com/kernel/mediatek;branch=android-mediatek-pike-3.10-oreo-wear-dr;protocol=https \
     file://0001-mediatek-ipanic-Remove-inline-to-fix-a-compilation-w.patch \

--- a/meta-pike/recipes-kernel/linux/linux-pike_o.bb
+++ b/meta-pike/recipes-kernel/linux/linux-pike_o.bb
@@ -20,6 +20,7 @@ SRC_URI = "git://android.googlesource.com/kernel/mediatek;branch=android-mediate
     file://0003-ARM-uaccess-remove-put_user-code-duplication.patch \
     file://0004-random-introduce-getrandom-2-system-call.patch \
     file://0005-ARM-wire-up-getrandom-syscall.patch \
+    file://0006-ARM-8933-1-replace-Sun-Solaris-style-flag-on-section.patch \
     file://defconfig \
     file://img_info"
 SRCREV = "5f7ba64dbb0f566149f5190db8c229da623a54bb"

--- a/meta-ray/recipes-kernel/linux/files/0006-ARM-8933-1-replace-Sun-Solaris-style-flag-on-section.patch
+++ b/meta-ray/recipes-kernel/linux/files/0006-ARM-8933-1-replace-Sun-Solaris-style-flag-on-section.patch
@@ -1,0 +1,141 @@
+From 4b9af45145c7f2bf2e0945008b143ffbfac2059f Mon Sep 17 00:00:00 2001
+From: casept <davids.paskevics@gmail.com>
+Date: Sun, 16 Jun 2024 01:45:31 +0200
+Subject: [PATCH] ARM: 8933/1: replace Sun/Solaris style flag on section
+ directive
+
+It looks like a section directive was using "Solaris style" to declare
+the section flags. Replace this with the GNU style so that Clang's
+integrated assembler can assemble this directive.
+
+The modified instances were identified via:
+$ ag \.section | grep #
+
+Link: https://ftp.gnu.org/old-gnu/Manuals/gas-2.9.1/html_chapter/as_7.html#SEC119
+Link: https://github.com/ClangBuiltLinux/linux/issues/744
+Link: https://bugs.llvm.org/show_bug.cgi?id=43759
+Link: https://reviews.llvm.org/D69296
+
+Acked-by: Nicolas Pitre <nico@fluxnic.net>
+Reviewed-by: Ard Biesheuvel <ardb@kernel.org>
+Reviewed-by: Stefan Agner <stefan@agner.ch>
+Signed-off-by: Nick Desaulniers <ndesaulniers@google.com>
+Suggested-by: Fangrui Song <maskray@google.com>
+Suggested-by: Jian Cai <jiancai@google.com>
+Suggested-by: Peter Smith <peter.smith@linaro.org>
+Signed-off-by: Russell King <rmk+kernel@armlinux.org.uk>
+[ partial backport to 3.18 ]
+---
+ arch/arm/boot/bootp/init.S              | 2 +-
+ arch/arm/boot/compressed/big-endian.S   | 2 +-
+ arch/arm/boot/compressed/head.S         | 2 +-
+ arch/arm/boot/compressed/piggy.gzip.S   | 2 +-
+ arch/arm/boot/compressed/piggy.lz4.S    | 2 +-
+ arch/arm/boot/compressed/piggy.lzma.S   | 2 +-
+ arch/arm/boot/compressed/piggy.lzo.S    | 2 +-
+ arch/arm/boot/compressed/piggy.xzkern.S | 2 +-
+ arch/arm/mm/proc-v7.S                   | 2 +-
+ 9 files changed, 9 insertions(+), 9 deletions(-)
+
+diff --git a/arch/arm/boot/bootp/init.S b/arch/arm/boot/bootp/init.S
+index 78b508075161..868eeeaaa46e 100644
+--- a/arch/arm/boot/bootp/init.S
++++ b/arch/arm/boot/bootp/init.S
+@@ -16,7 +16,7 @@
+  *  size immediately following the kernel, we could build this into
+  *  a binary blob, and concatenate the zImage using the cat command.
+  */
+-		.section .start,#alloc,#execinstr
++		.section .start, "ax"
+ 		.type	_start, #function
+ 		.globl	_start
+ 
+diff --git a/arch/arm/boot/compressed/big-endian.S b/arch/arm/boot/compressed/big-endian.S
+index 25ab26f1c6f0..f22428e275f8 100644
+--- a/arch/arm/boot/compressed/big-endian.S
++++ b/arch/arm/boot/compressed/big-endian.S
+@@ -5,7 +5,7 @@
+  *  Author: Nicolas Pitre
+  */
+ 
+-	.section ".start", #alloc, #execinstr
++	.section ".start", "ax"
+ 
+ 	mrc	p15, 0, r0, c1, c0, 0	@ read control reg
+ 	orr	r0, r0, #(1 << 7)	@ enable big endian mode
+diff --git a/arch/arm/boot/compressed/head.S b/arch/arm/boot/compressed/head.S
+index e9e0284fc8f2..ec0e837eecb2 100644
+--- a/arch/arm/boot/compressed/head.S
++++ b/arch/arm/boot/compressed/head.S
+@@ -109,7 +109,7 @@
+ #endif
+ 		.endm
+ 
+-		.section ".start", #alloc, #execinstr
++		.section ".start", "ax"
+ /*
+  * sort out different calling conventions
+  */
+diff --git a/arch/arm/boot/compressed/piggy.gzip.S b/arch/arm/boot/compressed/piggy.gzip.S
+index a68adf91a165..175ed02a6ac3 100644
+--- a/arch/arm/boot/compressed/piggy.gzip.S
++++ b/arch/arm/boot/compressed/piggy.gzip.S
+@@ -1,4 +1,4 @@
+-	.section .piggydata,#alloc
++	.section .piggydata, "a"
+ 	.globl	input_data
+ input_data:
+ 	.incbin	"arch/arm/boot/compressed/piggy.gzip"
+diff --git a/arch/arm/boot/compressed/piggy.lz4.S b/arch/arm/boot/compressed/piggy.lz4.S
+index 3d9a575618a3..710f07de46ed 100644
+--- a/arch/arm/boot/compressed/piggy.lz4.S
++++ b/arch/arm/boot/compressed/piggy.lz4.S
+@@ -1,4 +1,4 @@
+-	.section .piggydata,#alloc
++	.section .piggydata, "a"
+ 	.globl	input_data
+ input_data:
+ 	.incbin	"arch/arm/boot/compressed/piggy.lz4"
+diff --git a/arch/arm/boot/compressed/piggy.lzma.S b/arch/arm/boot/compressed/piggy.lzma.S
+index d7e69cffbc0a..cfea81ae8f4b 100644
+--- a/arch/arm/boot/compressed/piggy.lzma.S
++++ b/arch/arm/boot/compressed/piggy.lzma.S
+@@ -1,4 +1,4 @@
+-	.section .piggydata,#alloc
++	.section .piggydata, "a"
+ 	.globl	input_data
+ input_data:
+ 	.incbin	"arch/arm/boot/compressed/piggy.lzma"
+diff --git a/arch/arm/boot/compressed/piggy.lzo.S b/arch/arm/boot/compressed/piggy.lzo.S
+index a425ad95959a..236976d8dc7d 100644
+--- a/arch/arm/boot/compressed/piggy.lzo.S
++++ b/arch/arm/boot/compressed/piggy.lzo.S
+@@ -1,4 +1,4 @@
+-	.section .piggydata,#alloc
++	.section .piggydata, "a"
+ 	.globl	input_data
+ input_data:
+ 	.incbin	"arch/arm/boot/compressed/piggy.lzo"
+diff --git a/arch/arm/boot/compressed/piggy.xzkern.S b/arch/arm/boot/compressed/piggy.xzkern.S
+index 5703f300d027..a135d3b549c5 100644
+--- a/arch/arm/boot/compressed/piggy.xzkern.S
++++ b/arch/arm/boot/compressed/piggy.xzkern.S
+@@ -1,4 +1,4 @@
+-	.section .piggydata,#alloc
++	.section .piggydata, "a"
+ 	.globl	input_data
+ input_data:
+ 	.incbin	"arch/arm/boot/compressed/piggy.xzkern"
+diff --git a/arch/arm/mm/proc-v7.S b/arch/arm/mm/proc-v7.S
+index 22ac2a6fbfe3..68744e1c3643 100644
+--- a/arch/arm/mm/proc-v7.S
++++ b/arch/arm/mm/proc-v7.S
+@@ -462,7 +462,7 @@ __v7_setup_stack:
+ 	string	cpu_elf_name, "v7"
+ 	.align
+ 
+-	.section ".proc.info.init", #alloc, #execinstr
++	.section ".proc.info.init", "ax"
+ 
+ 	/*
+ 	 * Standard v7 proc info content

--- a/meta-ray/recipes-kernel/linux/linux-firefish_o.bb
+++ b/meta-ray/recipes-kernel/linux/linux-firefish_o.bb
@@ -8,15 +8,16 @@ LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://COPYING;md5=d7810fab7487fb0aad327b76f1be7cd7"
 COMPATIBLE_MACHINE = "firefish"
 
-SRC_URI = " git://android.googlesource.com/kernel/msm;branch=android-msm-firefish-3.18-oreo-wear-dr;protocol=https \
-    file://defconfig \
-    file://img_info \
-    file://0001-scripts-dtc-Remove-redundant-YYLOC-global-declaratio.patch \
-    file://0002-ARM-uaccess-remove-put_user-code-duplication.patch \
-    file://0003-touchscreen-raydium-Add-delay-for-wakeup-report.patch \
-    file://0004-Backport-mainline-4.1-Bluetooth-subsystem.patch \
-    file://0005-video-mdp3-Continue-when-the-overlay-wasn-t-released.patch \
-"
+SRC_URI = "git://android.googlesource.com/kernel/msm;branch=android-msm-firefish-3.18-oreo-wear-dr;protocol=https \
+           file://defconfig \
+           file://img_info \
+           file://0001-scripts-dtc-Remove-redundant-YYLOC-global-declaratio.patch \
+           file://0002-ARM-uaccess-remove-put_user-code-duplication.patch \
+           file://0003-touchscreen-raydium-Add-delay-for-wakeup-report.patch \
+           file://0004-Backport-mainline-4.1-Bluetooth-subsystem.patch \
+           file://0005-video-mdp3-Continue-when-the-overlay-wasn-t-released.patch \
+           file://0006-ARM-8933-1-replace-Sun-Solaris-style-flag-on-section.patch \
+           "
 
 SRCREV = "20d62df1b6b88de89184cbd1bf826291f43ddec8"
 LINUX_VERSION ?= "3.18"

--- a/meta-ray/recipes-kernel/linux/linux-ray_n.bb
+++ b/meta-ray/recipes-kernel/linux/linux-ray_n.bb
@@ -16,6 +16,7 @@ SRC_URI = " git://android.googlesource.com/kernel/msm;branch=android-msm-ray-3.1
     file://0003-touchscreen-raydium-Add-delay-for-wakeup-report.patch \
     file://0004-Backport-mainline-4.1-Bluetooth-subsystem.patch \
     file://0005-video-mdp3-Continue-when-the-overlay-wasn-t-released.patch \
+    file://0006-ARM-8933-1-replace-Sun-Solaris-style-flag-on-section.patch \
 "
 
 SRCREV = "ceb81fda35a733c904776eaaabd72dddf1e603c9"

--- a/meta-sawfish/recipes-kernel/linux/linux-sawfish/0011-ARM-8933-1-replace-Sun-Solaris-style-flag-on-section.patch
+++ b/meta-sawfish/recipes-kernel/linux/linux-sawfish/0011-ARM-8933-1-replace-Sun-Solaris-style-flag-on-section.patch
@@ -1,0 +1,141 @@
+From 94b0f9023e0f1a982c11d09107bb02bb9a3e821b Mon Sep 17 00:00:00 2001
+From: casept <davids.paskevics@gmail.com>
+Date: Sun, 16 Jun 2024 23:11:47 +0200
+Subject: [PATCH] ARM: 8933/1: replace Sun/Solaris style flag on section
+ directive
+
+It looks like a section directive was using "Solaris style" to declare
+the section flags. Replace this with the GNU style so that Clang's
+integrated assembler can assemble this directive.
+
+The modified instances were identified via:
+$ ag \.section | grep #
+
+Link: https://ftp.gnu.org/old-gnu/Manuals/gas-2.9.1/html_chapter/as_7.html#SEC119
+Link: https://github.com/ClangBuiltLinux/linux/issues/744
+Link: https://bugs.llvm.org/show_bug.cgi?id=43759
+Link: https://reviews.llvm.org/D69296
+
+Acked-by: Nicolas Pitre <nico@fluxnic.net>
+Reviewed-by: Ard Biesheuvel <ardb@kernel.org>
+Reviewed-by: Stefan Agner <stefan@agner.ch>
+Signed-off-by: Nick Desaulniers <ndesaulniers@google.com>
+Suggested-by: Fangrui Song <maskray@google.com>
+Suggested-by: Jian Cai <jiancai@google.com>
+Suggested-by: Peter Smith <peter.smith@linaro.org>
+Signed-off-by: Russell King <rmk+kernel@armlinux.org.uk>
+[ partial backport to 3.18 ]
+---
+ arch/arm/boot/bootp/init.S              | 2 +-
+ arch/arm/boot/compressed/big-endian.S   | 2 +-
+ arch/arm/boot/compressed/head.S         | 2 +-
+ arch/arm/boot/compressed/piggy.gzip.S   | 2 +-
+ arch/arm/boot/compressed/piggy.lz4.S    | 2 +-
+ arch/arm/boot/compressed/piggy.lzma.S   | 2 +-
+ arch/arm/boot/compressed/piggy.lzo.S    | 2 +-
+ arch/arm/boot/compressed/piggy.xzkern.S | 2 +-
+ arch/arm/mm/proc-v7.S                   | 2 +-
+ 9 files changed, 9 insertions(+), 9 deletions(-)
+
+diff --git a/arch/arm/boot/bootp/init.S b/arch/arm/boot/bootp/init.S
+index 78b508075161..868eeeaaa46e 100644
+--- a/arch/arm/boot/bootp/init.S
++++ b/arch/arm/boot/bootp/init.S
+@@ -16,7 +16,7 @@
+  *  size immediately following the kernel, we could build this into
+  *  a binary blob, and concatenate the zImage using the cat command.
+  */
+-		.section .start,#alloc,#execinstr
++		.section .start, "ax"
+ 		.type	_start, #function
+ 		.globl	_start
+ 
+diff --git a/arch/arm/boot/compressed/big-endian.S b/arch/arm/boot/compressed/big-endian.S
+index 25ab26f1c6f0..f22428e275f8 100644
+--- a/arch/arm/boot/compressed/big-endian.S
++++ b/arch/arm/boot/compressed/big-endian.S
+@@ -5,7 +5,7 @@
+  *  Author: Nicolas Pitre
+  */
+ 
+-	.section ".start", #alloc, #execinstr
++	.section ".start", "ax"
+ 
+ 	mrc	p15, 0, r0, c1, c0, 0	@ read control reg
+ 	orr	r0, r0, #(1 << 7)	@ enable big endian mode
+diff --git a/arch/arm/boot/compressed/head.S b/arch/arm/boot/compressed/head.S
+index e9e0284fc8f2..ec0e837eecb2 100644
+--- a/arch/arm/boot/compressed/head.S
++++ b/arch/arm/boot/compressed/head.S
+@@ -109,7 +109,7 @@
+ #endif
+ 		.endm
+ 
+-		.section ".start", #alloc, #execinstr
++		.section ".start", "ax"
+ /*
+  * sort out different calling conventions
+  */
+diff --git a/arch/arm/boot/compressed/piggy.gzip.S b/arch/arm/boot/compressed/piggy.gzip.S
+index a68adf91a165..175ed02a6ac3 100644
+--- a/arch/arm/boot/compressed/piggy.gzip.S
++++ b/arch/arm/boot/compressed/piggy.gzip.S
+@@ -1,4 +1,4 @@
+-	.section .piggydata,#alloc
++	.section .piggydata, "a"
+ 	.globl	input_data
+ input_data:
+ 	.incbin	"arch/arm/boot/compressed/piggy.gzip"
+diff --git a/arch/arm/boot/compressed/piggy.lz4.S b/arch/arm/boot/compressed/piggy.lz4.S
+index 3d9a575618a3..710f07de46ed 100644
+--- a/arch/arm/boot/compressed/piggy.lz4.S
++++ b/arch/arm/boot/compressed/piggy.lz4.S
+@@ -1,4 +1,4 @@
+-	.section .piggydata,#alloc
++	.section .piggydata, "a"
+ 	.globl	input_data
+ input_data:
+ 	.incbin	"arch/arm/boot/compressed/piggy.lz4"
+diff --git a/arch/arm/boot/compressed/piggy.lzma.S b/arch/arm/boot/compressed/piggy.lzma.S
+index d7e69cffbc0a..cfea81ae8f4b 100644
+--- a/arch/arm/boot/compressed/piggy.lzma.S
++++ b/arch/arm/boot/compressed/piggy.lzma.S
+@@ -1,4 +1,4 @@
+-	.section .piggydata,#alloc
++	.section .piggydata, "a"
+ 	.globl	input_data
+ input_data:
+ 	.incbin	"arch/arm/boot/compressed/piggy.lzma"
+diff --git a/arch/arm/boot/compressed/piggy.lzo.S b/arch/arm/boot/compressed/piggy.lzo.S
+index a425ad95959a..236976d8dc7d 100644
+--- a/arch/arm/boot/compressed/piggy.lzo.S
++++ b/arch/arm/boot/compressed/piggy.lzo.S
+@@ -1,4 +1,4 @@
+-	.section .piggydata,#alloc
++	.section .piggydata, "a"
+ 	.globl	input_data
+ input_data:
+ 	.incbin	"arch/arm/boot/compressed/piggy.lzo"
+diff --git a/arch/arm/boot/compressed/piggy.xzkern.S b/arch/arm/boot/compressed/piggy.xzkern.S
+index 5703f300d027..a135d3b549c5 100644
+--- a/arch/arm/boot/compressed/piggy.xzkern.S
++++ b/arch/arm/boot/compressed/piggy.xzkern.S
+@@ -1,4 +1,4 @@
+-	.section .piggydata,#alloc
++	.section .piggydata, "a"
+ 	.globl	input_data
+ input_data:
+ 	.incbin	"arch/arm/boot/compressed/piggy.xzkern"
+diff --git a/arch/arm/mm/proc-v7.S b/arch/arm/mm/proc-v7.S
+index 22ac2a6fbfe3..68744e1c3643 100644
+--- a/arch/arm/mm/proc-v7.S
++++ b/arch/arm/mm/proc-v7.S
+@@ -462,7 +462,7 @@ __v7_setup_stack:
+ 	string	cpu_elf_name, "v7"
+ 	.align
+ 
+-	.section ".proc.info.init", #alloc, #execinstr
++	.section ".proc.info.init", "ax"
+ 
+ 	/*
+ 	 * Standard v7 proc info content

--- a/meta-sawfish/recipes-kernel/linux/linux-sawfish_n.bb
+++ b/meta-sawfish/recipes-kernel/linux/linux-sawfish_n.bb
@@ -8,21 +8,22 @@ LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://COPYING;md5=d7810fab7487fb0aad327b76f1be7cd7"
 COMPATIBLE_MACHINE = "sawfish"
 
-SRC_URI = " git://android.googlesource.com/kernel/msm;branch=android-msm-sawshark-3.18-nougat-mr1-wear;protocol=https \
-    file://defconfig \
-    file://img_info \
-    file://0001-scripts-dtc-Remove-redundant-YYLOC-global-declaratio.patch \
-    file://0006-ARM-uaccess-remove-put_user-code-duplication.patch \
-    file://0003-mdss-Import-video-driver-from-Marshmallow.patch \
-    file://0004-Backport-mainline-4.1-Bluetooth-subsystem.patch \
-    file://0005-Revert-BT-Delete-the-file-board-8909-rfkill.c.patch \
-    file://0006-bluetooth-Import-Bluesleep-driver.patch \
-    file://0007-bluesleep-Use-kernel-s-HCI-events-instead-of-proc-bl.patch \
-    file://0008-Bluetooth-Fix-incorrect-gpio-definition-in-device-tr.patch \
-    file://0009-cyttp5-Add-delay-for-wakeup-report.patch \
-    file://0010-video-mdp3-Continue-when-the-overlay-wasn-t-released.patch \
-    file://00011-dts-sawshark-Remove-USB-gadget-function-list.patch \
-"
+SRC_URI = "git://android.googlesource.com/kernel/msm;branch=android-msm-sawshark-3.18-nougat-mr1-wear;protocol=https \
+           file://defconfig \
+           file://img_info \
+           file://0001-scripts-dtc-Remove-redundant-YYLOC-global-declaratio.patch \
+           file://0006-ARM-uaccess-remove-put_user-code-duplication.patch \
+           file://0003-mdss-Import-video-driver-from-Marshmallow.patch \
+           file://0004-Backport-mainline-4.1-Bluetooth-subsystem.patch \
+           file://0005-Revert-BT-Delete-the-file-board-8909-rfkill.c.patch \
+           file://0006-bluetooth-Import-Bluesleep-driver.patch \
+           file://0007-bluesleep-Use-kernel-s-HCI-events-instead-of-proc-bl.patch \
+           file://0008-Bluetooth-Fix-incorrect-gpio-definition-in-device-tr.patch \
+           file://0009-cyttp5-Add-delay-for-wakeup-report.patch \
+           file://0010-video-mdp3-Continue-when-the-overlay-wasn-t-released.patch \
+           file://00011-dts-sawshark-Remove-USB-gadget-function-list.patch \
+           file://0011-ARM-8933-1-replace-Sun-Solaris-style-flag-on-section.patch \
+           "
 
 SRCREV = "66cf3d5be07a599af417695e4f22f304af667979"
 LINUX_VERSION ?= "3.18"

--- a/meta-skipjack/recipes-kernel/linux/linux-skipjack/0012-ARM-8933-1-replace-Sun-Solaris-style-flag-on-section.patch
+++ b/meta-skipjack/recipes-kernel/linux/linux-skipjack/0012-ARM-8933-1-replace-Sun-Solaris-style-flag-on-section.patch
@@ -1,0 +1,141 @@
+From 94b0f9023e0f1a982c11d09107bb02bb9a3e821b Mon Sep 17 00:00:00 2001
+From: casept <davids.paskevics@gmail.com>
+Date: Sun, 16 Jun 2024 23:11:47 +0200
+Subject: [PATCH] ARM: 8933/1: replace Sun/Solaris style flag on section
+ directive
+
+It looks like a section directive was using "Solaris style" to declare
+the section flags. Replace this with the GNU style so that Clang's
+integrated assembler can assemble this directive.
+
+The modified instances were identified via:
+$ ag \.section | grep #
+
+Link: https://ftp.gnu.org/old-gnu/Manuals/gas-2.9.1/html_chapter/as_7.html#SEC119
+Link: https://github.com/ClangBuiltLinux/linux/issues/744
+Link: https://bugs.llvm.org/show_bug.cgi?id=43759
+Link: https://reviews.llvm.org/D69296
+
+Acked-by: Nicolas Pitre <nico@fluxnic.net>
+Reviewed-by: Ard Biesheuvel <ardb@kernel.org>
+Reviewed-by: Stefan Agner <stefan@agner.ch>
+Signed-off-by: Nick Desaulniers <ndesaulniers@google.com>
+Suggested-by: Fangrui Song <maskray@google.com>
+Suggested-by: Jian Cai <jiancai@google.com>
+Suggested-by: Peter Smith <peter.smith@linaro.org>
+Signed-off-by: Russell King <rmk+kernel@armlinux.org.uk>
+[ partial backport to 3.18 ]
+---
+ arch/arm/boot/bootp/init.S              | 2 +-
+ arch/arm/boot/compressed/big-endian.S   | 2 +-
+ arch/arm/boot/compressed/head.S         | 2 +-
+ arch/arm/boot/compressed/piggy.gzip.S   | 2 +-
+ arch/arm/boot/compressed/piggy.lz4.S    | 2 +-
+ arch/arm/boot/compressed/piggy.lzma.S   | 2 +-
+ arch/arm/boot/compressed/piggy.lzo.S    | 2 +-
+ arch/arm/boot/compressed/piggy.xzkern.S | 2 +-
+ arch/arm/mm/proc-v7.S                   | 2 +-
+ 9 files changed, 9 insertions(+), 9 deletions(-)
+
+diff --git a/arch/arm/boot/bootp/init.S b/arch/arm/boot/bootp/init.S
+index 78b508075161..868eeeaaa46e 100644
+--- a/arch/arm/boot/bootp/init.S
++++ b/arch/arm/boot/bootp/init.S
+@@ -16,7 +16,7 @@
+  *  size immediately following the kernel, we could build this into
+  *  a binary blob, and concatenate the zImage using the cat command.
+  */
+-		.section .start,#alloc,#execinstr
++		.section .start, "ax"
+ 		.type	_start, #function
+ 		.globl	_start
+ 
+diff --git a/arch/arm/boot/compressed/big-endian.S b/arch/arm/boot/compressed/big-endian.S
+index 25ab26f1c6f0..f22428e275f8 100644
+--- a/arch/arm/boot/compressed/big-endian.S
++++ b/arch/arm/boot/compressed/big-endian.S
+@@ -5,7 +5,7 @@
+  *  Author: Nicolas Pitre
+  */
+ 
+-	.section ".start", #alloc, #execinstr
++	.section ".start", "ax"
+ 
+ 	mrc	p15, 0, r0, c1, c0, 0	@ read control reg
+ 	orr	r0, r0, #(1 << 7)	@ enable big endian mode
+diff --git a/arch/arm/boot/compressed/head.S b/arch/arm/boot/compressed/head.S
+index e9e0284fc8f2..ec0e837eecb2 100644
+--- a/arch/arm/boot/compressed/head.S
++++ b/arch/arm/boot/compressed/head.S
+@@ -109,7 +109,7 @@
+ #endif
+ 		.endm
+ 
+-		.section ".start", #alloc, #execinstr
++		.section ".start", "ax"
+ /*
+  * sort out different calling conventions
+  */
+diff --git a/arch/arm/boot/compressed/piggy.gzip.S b/arch/arm/boot/compressed/piggy.gzip.S
+index a68adf91a165..175ed02a6ac3 100644
+--- a/arch/arm/boot/compressed/piggy.gzip.S
++++ b/arch/arm/boot/compressed/piggy.gzip.S
+@@ -1,4 +1,4 @@
+-	.section .piggydata,#alloc
++	.section .piggydata, "a"
+ 	.globl	input_data
+ input_data:
+ 	.incbin	"arch/arm/boot/compressed/piggy.gzip"
+diff --git a/arch/arm/boot/compressed/piggy.lz4.S b/arch/arm/boot/compressed/piggy.lz4.S
+index 3d9a575618a3..710f07de46ed 100644
+--- a/arch/arm/boot/compressed/piggy.lz4.S
++++ b/arch/arm/boot/compressed/piggy.lz4.S
+@@ -1,4 +1,4 @@
+-	.section .piggydata,#alloc
++	.section .piggydata, "a"
+ 	.globl	input_data
+ input_data:
+ 	.incbin	"arch/arm/boot/compressed/piggy.lz4"
+diff --git a/arch/arm/boot/compressed/piggy.lzma.S b/arch/arm/boot/compressed/piggy.lzma.S
+index d7e69cffbc0a..cfea81ae8f4b 100644
+--- a/arch/arm/boot/compressed/piggy.lzma.S
++++ b/arch/arm/boot/compressed/piggy.lzma.S
+@@ -1,4 +1,4 @@
+-	.section .piggydata,#alloc
++	.section .piggydata, "a"
+ 	.globl	input_data
+ input_data:
+ 	.incbin	"arch/arm/boot/compressed/piggy.lzma"
+diff --git a/arch/arm/boot/compressed/piggy.lzo.S b/arch/arm/boot/compressed/piggy.lzo.S
+index a425ad95959a..236976d8dc7d 100644
+--- a/arch/arm/boot/compressed/piggy.lzo.S
++++ b/arch/arm/boot/compressed/piggy.lzo.S
+@@ -1,4 +1,4 @@
+-	.section .piggydata,#alloc
++	.section .piggydata, "a"
+ 	.globl	input_data
+ input_data:
+ 	.incbin	"arch/arm/boot/compressed/piggy.lzo"
+diff --git a/arch/arm/boot/compressed/piggy.xzkern.S b/arch/arm/boot/compressed/piggy.xzkern.S
+index 5703f300d027..a135d3b549c5 100644
+--- a/arch/arm/boot/compressed/piggy.xzkern.S
++++ b/arch/arm/boot/compressed/piggy.xzkern.S
+@@ -1,4 +1,4 @@
+-	.section .piggydata,#alloc
++	.section .piggydata, "a"
+ 	.globl	input_data
+ input_data:
+ 	.incbin	"arch/arm/boot/compressed/piggy.xzkern"
+diff --git a/arch/arm/mm/proc-v7.S b/arch/arm/mm/proc-v7.S
+index 22ac2a6fbfe3..68744e1c3643 100644
+--- a/arch/arm/mm/proc-v7.S
++++ b/arch/arm/mm/proc-v7.S
+@@ -462,7 +462,7 @@ __v7_setup_stack:
+ 	string	cpu_elf_name, "v7"
+ 	.align
+ 
+-	.section ".proc.info.init", #alloc, #execinstr
++	.section ".proc.info.init", "ax"
+ 
+ 	/*
+ 	 * Standard v7 proc info content

--- a/meta-skipjack/recipes-kernel/linux/linux-skipjack_o.bb
+++ b/meta-skipjack/recipes-kernel/linux/linux-skipjack_o.bb
@@ -20,6 +20,7 @@ SRC_URI = "git://android.googlesource.com/kernel/msm;branch=android-msm-skipjack
     file://0009-touch-update-touch-firmware.patch \
     file://0010-touch-new-TP-ID-for-support-different-design.patch \
     file://0011-touch-new-TP-ID-for-support-different-design.patch \
+    file://0012-ARM-8933-1-replace-Sun-Solaris-style-flag-on-section.patch \
     file://defconfig \
     file://img_info"
 SRCREV = "f46a8c36f416d4245b13b451c36f36a0c690283d"

--- a/meta-smelt/recipes-kernel/linux/linux-smelt/0012-ARM-8933-1-replace-Sun-Solaris-style-flag-on-section.patch
+++ b/meta-smelt/recipes-kernel/linux/linux-smelt/0012-ARM-8933-1-replace-Sun-Solaris-style-flag-on-section.patch
@@ -1,0 +1,116 @@
+From 52b7b0ea9d9e4672dfc742f71cc6b08a8d10ffa7 Mon Sep 17 00:00:00 2001
+From: casept <davids.paskevics@gmail.com>
+Date: Sun, 16 Jun 2024 00:51:52 +0200
+Subject: [PATCH] ARM: 8933/1: replace Sun/Solaris style flag on section
+ directive
+
+It looks like a section directive was using "Solaris style" to declare
+the section flags. Replace this with the GNU style so that Clang's
+integrated assembler can assemble this directive.
+
+The modified instances were identified via:
+$ ag \.section | grep #
+
+Link: https://ftp.gnu.org/old-gnu/Manuals/gas-2.9.1/html_chapter/as_7.html#SEC119
+Link: https://github.com/ClangBuiltLinux/linux/issues/744
+Link: https://bugs.llvm.org/show_bug.cgi?id=43759
+Link: https://reviews.llvm.org/D69296
+
+Acked-by: Nicolas Pitre <nico@fluxnic.net>
+Reviewed-by: Ard Biesheuvel <ardb@kernel.org>
+Reviewed-by: Stefan Agner <stefan@agner.ch>
+Signed-off-by: Nick Desaulniers <ndesaulniers@google.com>
+Suggested-by: Fangrui Song <maskray@google.com>
+Suggested-by: Jian Cai <jiancai@google.com>
+Suggested-by: Peter Smith <peter.smith@linaro.org>
+Signed-off-by: Russell King <rmk+kernel@armlinux.org.uk>
+[ partial backport to 3.10 ]
+---
+ arch/arm/boot/compressed/big-endian.S   | 2 +-
+ arch/arm/boot/compressed/head.S         | 2 +-
+ arch/arm/boot/compressed/piggy.gzip.S   | 2 +-
+ arch/arm/boot/compressed/piggy.lzma.S   | 2 +-
+ arch/arm/boot/compressed/piggy.lzo.S    | 2 +-
+ arch/arm/boot/compressed/piggy.xzkern.S | 2 +-
+ arch/arm/mm/proc-v7.S                   | 2 +-
+ 7 files changed, 7 insertions(+), 7 deletions(-)
+
+diff --git a/arch/arm/boot/compressed/big-endian.S b/arch/arm/boot/compressed/big-endian.S
+index 25ab26f1c6f0..f22428e275f8 100644
+--- a/arch/arm/boot/compressed/big-endian.S
++++ b/arch/arm/boot/compressed/big-endian.S
+@@ -5,7 +5,7 @@
+  *  Author: Nicolas Pitre
+  */
+ 
+-	.section ".start", #alloc, #execinstr
++	.section ".start", "ax"
+ 
+ 	mrc	p15, 0, r0, c1, c0, 0	@ read control reg
+ 	orr	r0, r0, #(1 << 7)	@ enable big endian mode
+diff --git a/arch/arm/boot/compressed/head.S b/arch/arm/boot/compressed/head.S
+index fdd2e354ba3f..c5057234b014 100644
+--- a/arch/arm/boot/compressed/head.S
++++ b/arch/arm/boot/compressed/head.S
+@@ -114,7 +114,7 @@
+ #endif
+ 		.endm
+ 
+-		.section ".start", #alloc, #execinstr
++		.section ".start", "ax"
+ /*
+  * sort out different calling conventions
+  */
+diff --git a/arch/arm/boot/compressed/piggy.gzip.S b/arch/arm/boot/compressed/piggy.gzip.S
+index a68adf91a165..175ed02a6ac3 100644
+--- a/arch/arm/boot/compressed/piggy.gzip.S
++++ b/arch/arm/boot/compressed/piggy.gzip.S
+@@ -1,4 +1,4 @@
+-	.section .piggydata,#alloc
++	.section .piggydata, "a"
+ 	.globl	input_data
+ input_data:
+ 	.incbin	"arch/arm/boot/compressed/piggy.gzip"
+diff --git a/arch/arm/boot/compressed/piggy.lzma.S b/arch/arm/boot/compressed/piggy.lzma.S
+index d7e69cffbc0a..cfea81ae8f4b 100644
+--- a/arch/arm/boot/compressed/piggy.lzma.S
++++ b/arch/arm/boot/compressed/piggy.lzma.S
+@@ -1,4 +1,4 @@
+-	.section .piggydata,#alloc
++	.section .piggydata, "a"
+ 	.globl	input_data
+ input_data:
+ 	.incbin	"arch/arm/boot/compressed/piggy.lzma"
+diff --git a/arch/arm/boot/compressed/piggy.lzo.S b/arch/arm/boot/compressed/piggy.lzo.S
+index a425ad95959a..236976d8dc7d 100644
+--- a/arch/arm/boot/compressed/piggy.lzo.S
++++ b/arch/arm/boot/compressed/piggy.lzo.S
+@@ -1,4 +1,4 @@
+-	.section .piggydata,#alloc
++	.section .piggydata, "a"
+ 	.globl	input_data
+ input_data:
+ 	.incbin	"arch/arm/boot/compressed/piggy.lzo"
+diff --git a/arch/arm/boot/compressed/piggy.xzkern.S b/arch/arm/boot/compressed/piggy.xzkern.S
+index 5703f300d027..a135d3b549c5 100644
+--- a/arch/arm/boot/compressed/piggy.xzkern.S
++++ b/arch/arm/boot/compressed/piggy.xzkern.S
+@@ -1,4 +1,4 @@
+-	.section .piggydata,#alloc
++	.section .piggydata, "a"
+ 	.globl	input_data
+ input_data:
+ 	.incbin	"arch/arm/boot/compressed/piggy.xzkern"
+diff --git a/arch/arm/mm/proc-v7.S b/arch/arm/mm/proc-v7.S
+index 1f8597462b3a..050e3da34b9f 100644
+--- a/arch/arm/mm/proc-v7.S
++++ b/arch/arm/mm/proc-v7.S
+@@ -417,7 +417,7 @@ __v7_setup_stack:
+ 	string	cpu_elf_name, "v7"
+ 	.align
+ 
+-	.section ".proc.info.init", #alloc, #execinstr
++	.section ".proc.info.init", "ax"
+ 
+ 	/*
+ 	 * Standard v7 proc info content

--- a/meta-smelt/recipes-kernel/linux/linux-smelt_mm-mr1.bb
+++ b/meta-smelt/recipes-kernel/linux/linux-smelt_mm-mr1.bb
@@ -22,6 +22,7 @@ SRC_URI = " git://android.googlesource.com/kernel/msm;branch=android-msm-smelt-3
     file://0009-mdss_mdp_pipe-Don-t-allocate-first-RGB-pipe.patch \
     file://0010-random-introduce-getrandom-2-system-call.patch \
     file://0011-ARM-wire-up-getrandom-syscall.patch \
+    file://0012-ARM-8933-1-replace-Sun-Solaris-style-flag-on-section.patch \
 "
 
 SRCREV = "49608c8bfc75360f7ac54f539ce326b90034bc9d"

--- a/meta-sprat/recipes-kernel/linux/linux-sprat/0004-ARM-8933-1-replace-Sun-Solaris-style-flag-on-section.patch
+++ b/meta-sprat/recipes-kernel/linux/linux-sprat/0004-ARM-8933-1-replace-Sun-Solaris-style-flag-on-section.patch
@@ -1,0 +1,116 @@
+From 52b7b0ea9d9e4672dfc742f71cc6b08a8d10ffa7 Mon Sep 17 00:00:00 2001
+From: casept <davids.paskevics@gmail.com>
+Date: Sun, 16 Jun 2024 00:51:52 +0200
+Subject: [PATCH] ARM: 8933/1: replace Sun/Solaris style flag on section
+ directive
+
+It looks like a section directive was using "Solaris style" to declare
+the section flags. Replace this with the GNU style so that Clang's
+integrated assembler can assemble this directive.
+
+The modified instances were identified via:
+$ ag \.section | grep #
+
+Link: https://ftp.gnu.org/old-gnu/Manuals/gas-2.9.1/html_chapter/as_7.html#SEC119
+Link: https://github.com/ClangBuiltLinux/linux/issues/744
+Link: https://bugs.llvm.org/show_bug.cgi?id=43759
+Link: https://reviews.llvm.org/D69296
+
+Acked-by: Nicolas Pitre <nico@fluxnic.net>
+Reviewed-by: Ard Biesheuvel <ardb@kernel.org>
+Reviewed-by: Stefan Agner <stefan@agner.ch>
+Signed-off-by: Nick Desaulniers <ndesaulniers@google.com>
+Suggested-by: Fangrui Song <maskray@google.com>
+Suggested-by: Jian Cai <jiancai@google.com>
+Suggested-by: Peter Smith <peter.smith@linaro.org>
+Signed-off-by: Russell King <rmk+kernel@armlinux.org.uk>
+[ partial backport to 3.10 ]
+---
+ arch/arm/boot/compressed/big-endian.S   | 2 +-
+ arch/arm/boot/compressed/head.S         | 2 +-
+ arch/arm/boot/compressed/piggy.gzip.S   | 2 +-
+ arch/arm/boot/compressed/piggy.lzma.S   | 2 +-
+ arch/arm/boot/compressed/piggy.lzo.S    | 2 +-
+ arch/arm/boot/compressed/piggy.xzkern.S | 2 +-
+ arch/arm/mm/proc-v7.S                   | 2 +-
+ 7 files changed, 7 insertions(+), 7 deletions(-)
+
+diff --git a/arch/arm/boot/compressed/big-endian.S b/arch/arm/boot/compressed/big-endian.S
+index 25ab26f1c6f0..f22428e275f8 100644
+--- a/arch/arm/boot/compressed/big-endian.S
++++ b/arch/arm/boot/compressed/big-endian.S
+@@ -5,7 +5,7 @@
+  *  Author: Nicolas Pitre
+  */
+ 
+-	.section ".start", #alloc, #execinstr
++	.section ".start", "ax"
+ 
+ 	mrc	p15, 0, r0, c1, c0, 0	@ read control reg
+ 	orr	r0, r0, #(1 << 7)	@ enable big endian mode
+diff --git a/arch/arm/boot/compressed/head.S b/arch/arm/boot/compressed/head.S
+index fdd2e354ba3f..c5057234b014 100644
+--- a/arch/arm/boot/compressed/head.S
++++ b/arch/arm/boot/compressed/head.S
+@@ -114,7 +114,7 @@
+ #endif
+ 		.endm
+ 
+-		.section ".start", #alloc, #execinstr
++		.section ".start", "ax"
+ /*
+  * sort out different calling conventions
+  */
+diff --git a/arch/arm/boot/compressed/piggy.gzip.S b/arch/arm/boot/compressed/piggy.gzip.S
+index a68adf91a165..175ed02a6ac3 100644
+--- a/arch/arm/boot/compressed/piggy.gzip.S
++++ b/arch/arm/boot/compressed/piggy.gzip.S
+@@ -1,4 +1,4 @@
+-	.section .piggydata,#alloc
++	.section .piggydata, "a"
+ 	.globl	input_data
+ input_data:
+ 	.incbin	"arch/arm/boot/compressed/piggy.gzip"
+diff --git a/arch/arm/boot/compressed/piggy.lzma.S b/arch/arm/boot/compressed/piggy.lzma.S
+index d7e69cffbc0a..cfea81ae8f4b 100644
+--- a/arch/arm/boot/compressed/piggy.lzma.S
++++ b/arch/arm/boot/compressed/piggy.lzma.S
+@@ -1,4 +1,4 @@
+-	.section .piggydata,#alloc
++	.section .piggydata, "a"
+ 	.globl	input_data
+ input_data:
+ 	.incbin	"arch/arm/boot/compressed/piggy.lzma"
+diff --git a/arch/arm/boot/compressed/piggy.lzo.S b/arch/arm/boot/compressed/piggy.lzo.S
+index a425ad95959a..236976d8dc7d 100644
+--- a/arch/arm/boot/compressed/piggy.lzo.S
++++ b/arch/arm/boot/compressed/piggy.lzo.S
+@@ -1,4 +1,4 @@
+-	.section .piggydata,#alloc
++	.section .piggydata, "a"
+ 	.globl	input_data
+ input_data:
+ 	.incbin	"arch/arm/boot/compressed/piggy.lzo"
+diff --git a/arch/arm/boot/compressed/piggy.xzkern.S b/arch/arm/boot/compressed/piggy.xzkern.S
+index 5703f300d027..a135d3b549c5 100644
+--- a/arch/arm/boot/compressed/piggy.xzkern.S
++++ b/arch/arm/boot/compressed/piggy.xzkern.S
+@@ -1,4 +1,4 @@
+-	.section .piggydata,#alloc
++	.section .piggydata, "a"
+ 	.globl	input_data
+ input_data:
+ 	.incbin	"arch/arm/boot/compressed/piggy.xzkern"
+diff --git a/arch/arm/mm/proc-v7.S b/arch/arm/mm/proc-v7.S
+index 1f8597462b3a..050e3da34b9f 100644
+--- a/arch/arm/mm/proc-v7.S
++++ b/arch/arm/mm/proc-v7.S
+@@ -417,7 +417,7 @@ __v7_setup_stack:
+ 	string	cpu_elf_name, "v7"
+ 	.align
+ 
+-	.section ".proc.info.init", #alloc, #execinstr
++	.section ".proc.info.init", "ax"
+ 
+ 	/*
+ 	 * Standard v7 proc info content

--- a/meta-sprat/recipes-kernel/linux/linux-sprat_mm-dr1.bb
+++ b/meta-sprat/recipes-kernel/linux/linux-sprat_mm-dr1.bb
@@ -13,7 +13,9 @@ SRC_URI = "git://android.googlesource.com/kernel/msm;branch=android-msm-sprat-3.
     file://img_info \
     file://0001-scripts-dtc-Remove-redundant-YYLOC-global-declaratio.patch \
     file://0002-Backport-mainline-4.1-Bluetooth-subsystem.patch \
-    file://0003-ARM-uaccess-remove-put_user-code-duplication.patch"
+    file://0003-ARM-uaccess-remove-put_user-code-duplication.patch \
+    file://0004-ARM-8933-1-replace-Sun-Solaris-style-flag-on-section.patch \
+"
 SRCREV = "e0702f61b2736fe749bc31aa06fbdc5349074c1a"
 LINUX_VERSION ?= "3.10"
 PV = "${LINUX_VERSION}+marshmallow"

--- a/meta-sturgeon/recipes-kernel/linux/linux-sturgeon/0013-ARM-8933-1-replace-Sun-Solaris-style-flag-on-section.patch
+++ b/meta-sturgeon/recipes-kernel/linux/linux-sturgeon/0013-ARM-8933-1-replace-Sun-Solaris-style-flag-on-section.patch
@@ -1,0 +1,116 @@
+From 52b7b0ea9d9e4672dfc742f71cc6b08a8d10ffa7 Mon Sep 17 00:00:00 2001
+From: casept <davids.paskevics@gmail.com>
+Date: Sun, 16 Jun 2024 00:51:52 +0200
+Subject: [PATCH] ARM: 8933/1: replace Sun/Solaris style flag on section
+ directive
+
+It looks like a section directive was using "Solaris style" to declare
+the section flags. Replace this with the GNU style so that Clang's
+integrated assembler can assemble this directive.
+
+The modified instances were identified via:
+$ ag \.section | grep #
+
+Link: https://ftp.gnu.org/old-gnu/Manuals/gas-2.9.1/html_chapter/as_7.html#SEC119
+Link: https://github.com/ClangBuiltLinux/linux/issues/744
+Link: https://bugs.llvm.org/show_bug.cgi?id=43759
+Link: https://reviews.llvm.org/D69296
+
+Acked-by: Nicolas Pitre <nico@fluxnic.net>
+Reviewed-by: Ard Biesheuvel <ardb@kernel.org>
+Reviewed-by: Stefan Agner <stefan@agner.ch>
+Signed-off-by: Nick Desaulniers <ndesaulniers@google.com>
+Suggested-by: Fangrui Song <maskray@google.com>
+Suggested-by: Jian Cai <jiancai@google.com>
+Suggested-by: Peter Smith <peter.smith@linaro.org>
+Signed-off-by: Russell King <rmk+kernel@armlinux.org.uk>
+[ partial backport to 3.10 ]
+---
+ arch/arm/boot/compressed/big-endian.S   | 2 +-
+ arch/arm/boot/compressed/head.S         | 2 +-
+ arch/arm/boot/compressed/piggy.gzip.S   | 2 +-
+ arch/arm/boot/compressed/piggy.lzma.S   | 2 +-
+ arch/arm/boot/compressed/piggy.lzo.S    | 2 +-
+ arch/arm/boot/compressed/piggy.xzkern.S | 2 +-
+ arch/arm/mm/proc-v7.S                   | 2 +-
+ 7 files changed, 7 insertions(+), 7 deletions(-)
+
+diff --git a/arch/arm/boot/compressed/big-endian.S b/arch/arm/boot/compressed/big-endian.S
+index 25ab26f1c6f0..f22428e275f8 100644
+--- a/arch/arm/boot/compressed/big-endian.S
++++ b/arch/arm/boot/compressed/big-endian.S
+@@ -5,7 +5,7 @@
+  *  Author: Nicolas Pitre
+  */
+ 
+-	.section ".start", #alloc, #execinstr
++	.section ".start", "ax"
+ 
+ 	mrc	p15, 0, r0, c1, c0, 0	@ read control reg
+ 	orr	r0, r0, #(1 << 7)	@ enable big endian mode
+diff --git a/arch/arm/boot/compressed/head.S b/arch/arm/boot/compressed/head.S
+index fdd2e354ba3f..c5057234b014 100644
+--- a/arch/arm/boot/compressed/head.S
++++ b/arch/arm/boot/compressed/head.S
+@@ -114,7 +114,7 @@
+ #endif
+ 		.endm
+ 
+-		.section ".start", #alloc, #execinstr
++		.section ".start", "ax"
+ /*
+  * sort out different calling conventions
+  */
+diff --git a/arch/arm/boot/compressed/piggy.gzip.S b/arch/arm/boot/compressed/piggy.gzip.S
+index a68adf91a165..175ed02a6ac3 100644
+--- a/arch/arm/boot/compressed/piggy.gzip.S
++++ b/arch/arm/boot/compressed/piggy.gzip.S
+@@ -1,4 +1,4 @@
+-	.section .piggydata,#alloc
++	.section .piggydata, "a"
+ 	.globl	input_data
+ input_data:
+ 	.incbin	"arch/arm/boot/compressed/piggy.gzip"
+diff --git a/arch/arm/boot/compressed/piggy.lzma.S b/arch/arm/boot/compressed/piggy.lzma.S
+index d7e69cffbc0a..cfea81ae8f4b 100644
+--- a/arch/arm/boot/compressed/piggy.lzma.S
++++ b/arch/arm/boot/compressed/piggy.lzma.S
+@@ -1,4 +1,4 @@
+-	.section .piggydata,#alloc
++	.section .piggydata, "a"
+ 	.globl	input_data
+ input_data:
+ 	.incbin	"arch/arm/boot/compressed/piggy.lzma"
+diff --git a/arch/arm/boot/compressed/piggy.lzo.S b/arch/arm/boot/compressed/piggy.lzo.S
+index a425ad95959a..236976d8dc7d 100644
+--- a/arch/arm/boot/compressed/piggy.lzo.S
++++ b/arch/arm/boot/compressed/piggy.lzo.S
+@@ -1,4 +1,4 @@
+-	.section .piggydata,#alloc
++	.section .piggydata, "a"
+ 	.globl	input_data
+ input_data:
+ 	.incbin	"arch/arm/boot/compressed/piggy.lzo"
+diff --git a/arch/arm/boot/compressed/piggy.xzkern.S b/arch/arm/boot/compressed/piggy.xzkern.S
+index 5703f300d027..a135d3b549c5 100644
+--- a/arch/arm/boot/compressed/piggy.xzkern.S
++++ b/arch/arm/boot/compressed/piggy.xzkern.S
+@@ -1,4 +1,4 @@
+-	.section .piggydata,#alloc
++	.section .piggydata, "a"
+ 	.globl	input_data
+ input_data:
+ 	.incbin	"arch/arm/boot/compressed/piggy.xzkern"
+diff --git a/arch/arm/mm/proc-v7.S b/arch/arm/mm/proc-v7.S
+index 1f8597462b3a..050e3da34b9f 100644
+--- a/arch/arm/mm/proc-v7.S
++++ b/arch/arm/mm/proc-v7.S
+@@ -417,7 +417,7 @@ __v7_setup_stack:
+ 	string	cpu_elf_name, "v7"
+ 	.align
+ 
+-	.section ".proc.info.init", #alloc, #execinstr
++	.section ".proc.info.init", "ax"
+ 
+ 	/*
+ 	 * Standard v7 proc info content

--- a/meta-sturgeon/recipes-kernel/linux/linux-sturgeon_mm-mr1.bb
+++ b/meta-sturgeon/recipes-kernel/linux/linux-sturgeon_mm-mr1.bb
@@ -23,6 +23,7 @@ SRC_URI = " git://android.googlesource.com/kernel/msm;branch=android-msm-sturgeo
     file://0010-synaptics_i2c_rmi4-Adds-a-wakelock-when-the-screen-i.patch \
     file://0011-random-introduce-getrandom-2-system-call.patch \
     file://0012-ARM-wire-up-getrandom-syscall.patch \
+    file://0013-ARM-8933-1-replace-Sun-Solaris-style-flag-on-section.patch \
 "
 
 SRCREV = "97abcf5b24684a46530ffc8a4748dd7ae6c2e65a"

--- a/meta-swift/recipes-kernel/linux/linux-swift/0004-ARM-8933-1-replace-Sun-Solaris-style-flag-on-section.patch
+++ b/meta-swift/recipes-kernel/linux/linux-swift/0004-ARM-8933-1-replace-Sun-Solaris-style-flag-on-section.patch
@@ -1,0 +1,141 @@
+From 94b0f9023e0f1a982c11d09107bb02bb9a3e821b Mon Sep 17 00:00:00 2001
+From: casept <davids.paskevics@gmail.com>
+Date: Sun, 16 Jun 2024 23:11:47 +0200
+Subject: [PATCH] ARM: 8933/1: replace Sun/Solaris style flag on section
+ directive
+
+It looks like a section directive was using "Solaris style" to declare
+the section flags. Replace this with the GNU style so that Clang's
+integrated assembler can assemble this directive.
+
+The modified instances were identified via:
+$ ag \.section | grep #
+
+Link: https://ftp.gnu.org/old-gnu/Manuals/gas-2.9.1/html_chapter/as_7.html#SEC119
+Link: https://github.com/ClangBuiltLinux/linux/issues/744
+Link: https://bugs.llvm.org/show_bug.cgi?id=43759
+Link: https://reviews.llvm.org/D69296
+
+Acked-by: Nicolas Pitre <nico@fluxnic.net>
+Reviewed-by: Ard Biesheuvel <ardb@kernel.org>
+Reviewed-by: Stefan Agner <stefan@agner.ch>
+Signed-off-by: Nick Desaulniers <ndesaulniers@google.com>
+Suggested-by: Fangrui Song <maskray@google.com>
+Suggested-by: Jian Cai <jiancai@google.com>
+Suggested-by: Peter Smith <peter.smith@linaro.org>
+Signed-off-by: Russell King <rmk+kernel@armlinux.org.uk>
+[ partial backport to 3.18 ]
+---
+ arch/arm/boot/bootp/init.S              | 2 +-
+ arch/arm/boot/compressed/big-endian.S   | 2 +-
+ arch/arm/boot/compressed/head.S         | 2 +-
+ arch/arm/boot/compressed/piggy.gzip.S   | 2 +-
+ arch/arm/boot/compressed/piggy.lz4.S    | 2 +-
+ arch/arm/boot/compressed/piggy.lzma.S   | 2 +-
+ arch/arm/boot/compressed/piggy.lzo.S    | 2 +-
+ arch/arm/boot/compressed/piggy.xzkern.S | 2 +-
+ arch/arm/mm/proc-v7.S                   | 2 +-
+ 9 files changed, 9 insertions(+), 9 deletions(-)
+
+diff --git a/arch/arm/boot/bootp/init.S b/arch/arm/boot/bootp/init.S
+index 78b508075161..868eeeaaa46e 100644
+--- a/arch/arm/boot/bootp/init.S
++++ b/arch/arm/boot/bootp/init.S
+@@ -16,7 +16,7 @@
+  *  size immediately following the kernel, we could build this into
+  *  a binary blob, and concatenate the zImage using the cat command.
+  */
+-		.section .start,#alloc,#execinstr
++		.section .start, "ax"
+ 		.type	_start, #function
+ 		.globl	_start
+ 
+diff --git a/arch/arm/boot/compressed/big-endian.S b/arch/arm/boot/compressed/big-endian.S
+index 25ab26f1c6f0..f22428e275f8 100644
+--- a/arch/arm/boot/compressed/big-endian.S
++++ b/arch/arm/boot/compressed/big-endian.S
+@@ -5,7 +5,7 @@
+  *  Author: Nicolas Pitre
+  */
+ 
+-	.section ".start", #alloc, #execinstr
++	.section ".start", "ax"
+ 
+ 	mrc	p15, 0, r0, c1, c0, 0	@ read control reg
+ 	orr	r0, r0, #(1 << 7)	@ enable big endian mode
+diff --git a/arch/arm/boot/compressed/head.S b/arch/arm/boot/compressed/head.S
+index e9e0284fc8f2..ec0e837eecb2 100644
+--- a/arch/arm/boot/compressed/head.S
++++ b/arch/arm/boot/compressed/head.S
+@@ -109,7 +109,7 @@
+ #endif
+ 		.endm
+ 
+-		.section ".start", #alloc, #execinstr
++		.section ".start", "ax"
+ /*
+  * sort out different calling conventions
+  */
+diff --git a/arch/arm/boot/compressed/piggy.gzip.S b/arch/arm/boot/compressed/piggy.gzip.S
+index a68adf91a165..175ed02a6ac3 100644
+--- a/arch/arm/boot/compressed/piggy.gzip.S
++++ b/arch/arm/boot/compressed/piggy.gzip.S
+@@ -1,4 +1,4 @@
+-	.section .piggydata,#alloc
++	.section .piggydata, "a"
+ 	.globl	input_data
+ input_data:
+ 	.incbin	"arch/arm/boot/compressed/piggy.gzip"
+diff --git a/arch/arm/boot/compressed/piggy.lz4.S b/arch/arm/boot/compressed/piggy.lz4.S
+index 3d9a575618a3..710f07de46ed 100644
+--- a/arch/arm/boot/compressed/piggy.lz4.S
++++ b/arch/arm/boot/compressed/piggy.lz4.S
+@@ -1,4 +1,4 @@
+-	.section .piggydata,#alloc
++	.section .piggydata, "a"
+ 	.globl	input_data
+ input_data:
+ 	.incbin	"arch/arm/boot/compressed/piggy.lz4"
+diff --git a/arch/arm/boot/compressed/piggy.lzma.S b/arch/arm/boot/compressed/piggy.lzma.S
+index d7e69cffbc0a..cfea81ae8f4b 100644
+--- a/arch/arm/boot/compressed/piggy.lzma.S
++++ b/arch/arm/boot/compressed/piggy.lzma.S
+@@ -1,4 +1,4 @@
+-	.section .piggydata,#alloc
++	.section .piggydata, "a"
+ 	.globl	input_data
+ input_data:
+ 	.incbin	"arch/arm/boot/compressed/piggy.lzma"
+diff --git a/arch/arm/boot/compressed/piggy.lzo.S b/arch/arm/boot/compressed/piggy.lzo.S
+index a425ad95959a..236976d8dc7d 100644
+--- a/arch/arm/boot/compressed/piggy.lzo.S
++++ b/arch/arm/boot/compressed/piggy.lzo.S
+@@ -1,4 +1,4 @@
+-	.section .piggydata,#alloc
++	.section .piggydata, "a"
+ 	.globl	input_data
+ input_data:
+ 	.incbin	"arch/arm/boot/compressed/piggy.lzo"
+diff --git a/arch/arm/boot/compressed/piggy.xzkern.S b/arch/arm/boot/compressed/piggy.xzkern.S
+index 5703f300d027..a135d3b549c5 100644
+--- a/arch/arm/boot/compressed/piggy.xzkern.S
++++ b/arch/arm/boot/compressed/piggy.xzkern.S
+@@ -1,4 +1,4 @@
+-	.section .piggydata,#alloc
++	.section .piggydata, "a"
+ 	.globl	input_data
+ input_data:
+ 	.incbin	"arch/arm/boot/compressed/piggy.xzkern"
+diff --git a/arch/arm/mm/proc-v7.S b/arch/arm/mm/proc-v7.S
+index 22ac2a6fbfe3..68744e1c3643 100644
+--- a/arch/arm/mm/proc-v7.S
++++ b/arch/arm/mm/proc-v7.S
+@@ -462,7 +462,7 @@ __v7_setup_stack:
+ 	string	cpu_elf_name, "v7"
+ 	.align
+ 
+-	.section ".proc.info.init", #alloc, #execinstr
++	.section ".proc.info.init", "ax"
+ 
+ 	/*
+ 	 * Standard v7 proc info content

--- a/meta-swift/recipes-kernel/linux/linux-swift_mm-mr1.bb
+++ b/meta-swift/recipes-kernel/linux/linux-swift_mm-mr1.bb
@@ -12,7 +12,9 @@ SRC_URI = "git://android.googlesource.com/kernel/msm;branch=android-msm-swift-3.
     file://defconfig \
     file://img_info \
     file://0001-scripts-dtc-Remove-redundant-YYLOC-global-declaratio.patch \
-    file://0003-ARM-uaccess-remove-put_user-code-duplication.patch"
+    file://0003-ARM-uaccess-remove-put_user-code-duplication.patch \
+    file://0004-ARM-8933-1-replace-Sun-Solaris-style-flag-on-section.patch \
+    "
 SRCREV = "2f958570bcf7457da4827dc8da5ff3195d447cb3"
 LINUX_VERSION ?= "3.18"
 PV = "${LINUX_VERSION}+marshmallow"

--- a/meta-tetra/recipes-kernel/linux/linux-tetra/0014-ARM-8933-1-replace-Sun-Solaris-style-flag-on-section.patch
+++ b/meta-tetra/recipes-kernel/linux/linux-tetra/0014-ARM-8933-1-replace-Sun-Solaris-style-flag-on-section.patch
@@ -1,0 +1,116 @@
+From 52b7b0ea9d9e4672dfc742f71cc6b08a8d10ffa7 Mon Sep 17 00:00:00 2001
+From: casept <davids.paskevics@gmail.com>
+Date: Sun, 16 Jun 2024 00:51:52 +0200
+Subject: [PATCH] ARM: 8933/1: replace Sun/Solaris style flag on section
+ directive
+
+It looks like a section directive was using "Solaris style" to declare
+the section flags. Replace this with the GNU style so that Clang's
+integrated assembler can assemble this directive.
+
+The modified instances were identified via:
+$ ag \.section | grep #
+
+Link: https://ftp.gnu.org/old-gnu/Manuals/gas-2.9.1/html_chapter/as_7.html#SEC119
+Link: https://github.com/ClangBuiltLinux/linux/issues/744
+Link: https://bugs.llvm.org/show_bug.cgi?id=43759
+Link: https://reviews.llvm.org/D69296
+
+Acked-by: Nicolas Pitre <nico@fluxnic.net>
+Reviewed-by: Ard Biesheuvel <ardb@kernel.org>
+Reviewed-by: Stefan Agner <stefan@agner.ch>
+Signed-off-by: Nick Desaulniers <ndesaulniers@google.com>
+Suggested-by: Fangrui Song <maskray@google.com>
+Suggested-by: Jian Cai <jiancai@google.com>
+Suggested-by: Peter Smith <peter.smith@linaro.org>
+Signed-off-by: Russell King <rmk+kernel@armlinux.org.uk>
+[ partial backport to 3.10 ]
+---
+ arch/arm/boot/compressed/big-endian.S   | 2 +-
+ arch/arm/boot/compressed/head.S         | 2 +-
+ arch/arm/boot/compressed/piggy.gzip.S   | 2 +-
+ arch/arm/boot/compressed/piggy.lzma.S   | 2 +-
+ arch/arm/boot/compressed/piggy.lzo.S    | 2 +-
+ arch/arm/boot/compressed/piggy.xzkern.S | 2 +-
+ arch/arm/mm/proc-v7.S                   | 2 +-
+ 7 files changed, 7 insertions(+), 7 deletions(-)
+
+diff --git a/arch/arm/boot/compressed/big-endian.S b/arch/arm/boot/compressed/big-endian.S
+index 25ab26f1c6f0..f22428e275f8 100644
+--- a/arch/arm/boot/compressed/big-endian.S
++++ b/arch/arm/boot/compressed/big-endian.S
+@@ -5,7 +5,7 @@
+  *  Author: Nicolas Pitre
+  */
+ 
+-	.section ".start", #alloc, #execinstr
++	.section ".start", "ax"
+ 
+ 	mrc	p15, 0, r0, c1, c0, 0	@ read control reg
+ 	orr	r0, r0, #(1 << 7)	@ enable big endian mode
+diff --git a/arch/arm/boot/compressed/head.S b/arch/arm/boot/compressed/head.S
+index fdd2e354ba3f..c5057234b014 100644
+--- a/arch/arm/boot/compressed/head.S
++++ b/arch/arm/boot/compressed/head.S
+@@ -114,7 +114,7 @@
+ #endif
+ 		.endm
+ 
+-		.section ".start", #alloc, #execinstr
++		.section ".start", "ax"
+ /*
+  * sort out different calling conventions
+  */
+diff --git a/arch/arm/boot/compressed/piggy.gzip.S b/arch/arm/boot/compressed/piggy.gzip.S
+index a68adf91a165..175ed02a6ac3 100644
+--- a/arch/arm/boot/compressed/piggy.gzip.S
++++ b/arch/arm/boot/compressed/piggy.gzip.S
+@@ -1,4 +1,4 @@
+-	.section .piggydata,#alloc
++	.section .piggydata, "a"
+ 	.globl	input_data
+ input_data:
+ 	.incbin	"arch/arm/boot/compressed/piggy.gzip"
+diff --git a/arch/arm/boot/compressed/piggy.lzma.S b/arch/arm/boot/compressed/piggy.lzma.S
+index d7e69cffbc0a..cfea81ae8f4b 100644
+--- a/arch/arm/boot/compressed/piggy.lzma.S
++++ b/arch/arm/boot/compressed/piggy.lzma.S
+@@ -1,4 +1,4 @@
+-	.section .piggydata,#alloc
++	.section .piggydata, "a"
+ 	.globl	input_data
+ input_data:
+ 	.incbin	"arch/arm/boot/compressed/piggy.lzma"
+diff --git a/arch/arm/boot/compressed/piggy.lzo.S b/arch/arm/boot/compressed/piggy.lzo.S
+index a425ad95959a..236976d8dc7d 100644
+--- a/arch/arm/boot/compressed/piggy.lzo.S
++++ b/arch/arm/boot/compressed/piggy.lzo.S
+@@ -1,4 +1,4 @@
+-	.section .piggydata,#alloc
++	.section .piggydata, "a"
+ 	.globl	input_data
+ input_data:
+ 	.incbin	"arch/arm/boot/compressed/piggy.lzo"
+diff --git a/arch/arm/boot/compressed/piggy.xzkern.S b/arch/arm/boot/compressed/piggy.xzkern.S
+index 5703f300d027..a135d3b549c5 100644
+--- a/arch/arm/boot/compressed/piggy.xzkern.S
++++ b/arch/arm/boot/compressed/piggy.xzkern.S
+@@ -1,4 +1,4 @@
+-	.section .piggydata,#alloc
++	.section .piggydata, "a"
+ 	.globl	input_data
+ input_data:
+ 	.incbin	"arch/arm/boot/compressed/piggy.xzkern"
+diff --git a/arch/arm/mm/proc-v7.S b/arch/arm/mm/proc-v7.S
+index 1f8597462b3a..050e3da34b9f 100644
+--- a/arch/arm/mm/proc-v7.S
++++ b/arch/arm/mm/proc-v7.S
+@@ -417,7 +417,7 @@ __v7_setup_stack:
+ 	string	cpu_elf_name, "v7"
+ 	.align
+ 
+-	.section ".proc.info.init", #alloc, #execinstr
++	.section ".proc.info.init", "ax"
+ 
+ 	/*
+ 	 * Standard v7 proc info content

--- a/meta-tetra/recipes-kernel/linux/linux-tetra_mm-dr1.bb
+++ b/meta-tetra/recipes-kernel/linux/linux-tetra_mm-dr1.bb
@@ -11,6 +11,8 @@ COMPATIBLE_MACHINE = "tetra"
 # Use an older version of gcc (gcc >= 9 doesn't boot.)
 DEPENDS:remove = "virtual/${TARGET_PREFIX}gcc"
 DEPENDS += "virtual/${TARGET_PREFIX}gcc8"
+# Ancient GCC doesn't support this flag
+DEBUG_PREFIX_MAP:remove = "-fcanon-prefix-map"
 
 SRC_URI = "git://android.googlesource.com/kernel/bcm;branch=android-bcm-tetra-3.10-marshmallow-dr1-wear-release;protocol=https \
     file://defconfig \

--- a/meta-tetra/recipes-kernel/linux/linux-tetra_mm-dr1.bb
+++ b/meta-tetra/recipes-kernel/linux/linux-tetra_mm-dr1.bb
@@ -28,6 +28,7 @@ SRC_URI = "git://android.googlesource.com/kernel/bcm;branch=android-bcm-tetra-3.
     file://0011-broadcom-modem-rpc-Disable-logs-which-cause-a-compil.patch \
     file://0012-random-introduce-getrandom-2-system-call.patch \
     file://0013-ARM-wire-up-getrandom-syscall.patch \
+    file://0014-ARM-8933-1-replace-Sun-Solaris-style-flag-on-section.patch \
 "
 SRCREV = "0de8b342797a4074625055e77d37d5367d8ff285"
 LINUX_VERSION ?= "3.10"

--- a/meta-triggerfish/recipes-kernel/linux/linux-triggerfish/0004-ARM-8933-1-replace-Sun-Solaris-style-flag-on-section.patch
+++ b/meta-triggerfish/recipes-kernel/linux/linux-triggerfish/0004-ARM-8933-1-replace-Sun-Solaris-style-flag-on-section.patch
@@ -1,0 +1,97 @@
+From 08c1823ebe15bbc152a1a022b2dd9461767642f2 Mon Sep 17 00:00:00 2001
+From: casept <davids.paskevics@gmail.com>
+Date: Tue, 18 Jun 2024 01:32:33 +0200
+Subject: [PATCH] ARM: 8933/1: replace Sun/Solaris style flag on section
+ directive
+
+It looks like a section directive was using "Solaris style" to declare
+the section flags. Replace this with the GNU style so that Clang's
+integrated assembler can assemble this directive.
+
+The modified instances were identified via:
+$ ag \.section | grep #
+
+Link: https://ftp.gnu.org/old-gnu/Manuals/gas-2.9.1/html_chapter/as_7.html#SEC119
+Link: https://github.com/ClangBuiltLinux/linux/issues/744
+Link: https://bugs.llvm.org/show_bug.cgi?id=43759
+Link: https://reviews.llvm.org/D69296
+
+Acked-by: Nicolas Pitre <nico@fluxnic.net>
+Reviewed-by: Ard Biesheuvel <ardb@kernel.org>
+Reviewed-by: Stefan Agner <stefan@agner.ch>
+Signed-off-by: Nick Desaulniers <ndesaulniers@google.com>
+Suggested-by: Fangrui Song <maskray@google.com>
+Suggested-by: Jian Cai <jiancai@google.com>
+Suggested-by: Peter Smith <peter.smith@linaro.org>
+Signed-off-by: Russell King <rmk+kernel@armlinux.org.uk>
+[ partial backport to 4.9 ]
+---
+ arch/arm/boot/bootp/init.S            | 2 +-
+ arch/arm/boot/compressed/big-endian.S | 2 +-
+ arch/arm/boot/compressed/head.S       | 2 +-
+ arch/arm/boot/compressed/piggy.S      | 2 +-
+ arch/arm/mm/proc-v7.S                 | 2 +-
+ 5 files changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/arch/arm/boot/bootp/init.S b/arch/arm/boot/bootp/init.S
+index 78b508075161..868eeeaaa46e 100644
+--- a/arch/arm/boot/bootp/init.S
++++ b/arch/arm/boot/bootp/init.S
+@@ -16,7 +16,7 @@
+  *  size immediately following the kernel, we could build this into
+  *  a binary blob, and concatenate the zImage using the cat command.
+  */
+-		.section .start,#alloc,#execinstr
++		.section .start, "ax"
+ 		.type	_start, #function
+ 		.globl	_start
+ 
+diff --git a/arch/arm/boot/compressed/big-endian.S b/arch/arm/boot/compressed/big-endian.S
+index 25ab26f1c6f0..f22428e275f8 100644
+--- a/arch/arm/boot/compressed/big-endian.S
++++ b/arch/arm/boot/compressed/big-endian.S
+@@ -5,7 +5,7 @@
+  *  Author: Nicolas Pitre
+  */
+ 
+-	.section ".start", #alloc, #execinstr
++	.section ".start", "ax"
+ 
+ 	mrc	p15, 0, r0, c1, c0, 0	@ read control reg
+ 	orr	r0, r0, #(1 << 7)	@ enable big endian mode
+diff --git a/arch/arm/boot/compressed/head.S b/arch/arm/boot/compressed/head.S
+index 51fc9fb6dc2c..14bbcfe996e3 100644
+--- a/arch/arm/boot/compressed/head.S
++++ b/arch/arm/boot/compressed/head.S
+@@ -114,7 +114,7 @@
+ #endif
+ 		.endm
+ 
+-		.section ".start", #alloc, #execinstr
++		.section ".start", "ax"
+ /*
+  * sort out different calling conventions
+  */
+diff --git a/arch/arm/boot/compressed/piggy.S b/arch/arm/boot/compressed/piggy.S
+index f72088495f43..c2c1c8d68d7a 100644
+--- a/arch/arm/boot/compressed/piggy.S
++++ b/arch/arm/boot/compressed/piggy.S
+@@ -1,4 +1,4 @@
+-	.section .piggydata,#alloc
++	.section .piggydata, "a"
+ 	.globl	input_data
+ input_data:
+ 	.incbin	"arch/arm/boot/compressed/piggy_data"
+diff --git a/arch/arm/mm/proc-v7.S b/arch/arm/mm/proc-v7.S
+index 047d64640d8c..e44ed623116c 100644
+--- a/arch/arm/mm/proc-v7.S
++++ b/arch/arm/mm/proc-v7.S
+@@ -560,7 +560,7 @@ __v7_setup_stack:
+ 	string	cpu_elf_name, "v7"
+ 	.align
+ 
+-	.section ".proc.info.init", #alloc
++	.section ".proc.info.init", "a"
+ 
+ 	/*
+ 	 * Standard v7 proc info content

--- a/meta-triggerfish/recipes-kernel/linux/linux-triggerfish_p.bb
+++ b/meta-triggerfish/recipes-kernel/linux/linux-triggerfish_p.bb
@@ -22,7 +22,7 @@ SRC_URI = "git://android.googlesource.com/kernel/msm;branch=android-msm-triggerf
            "
 
 SRCREV = "82824770e036a1e7576a299bc37b52d633d62675"
-LINUX_VERSION ?= "3.18"
+LINUX_VERSION ?= "4.9"
 PV = "${LINUX_VERSION}+pie"
 S = "${WORKDIR}/git"
 B = "${S}"

--- a/meta-triggerfish/recipes-kernel/linux/linux-triggerfish_p.bb
+++ b/meta-triggerfish/recipes-kernel/linux/linux-triggerfish_p.bb
@@ -11,6 +11,8 @@ COMPATIBLE_MACHINE = "triggerfish"
 # Use an older version of gcc (gcc >= 9 doesn't boot.)
 DEPENDS:remove = "virtual/${TARGET_PREFIX}gcc"
 DEPENDS += "virtual/${TARGET_PREFIX}gcc8"
+# Ancient GCC doesn't support this flag
+DEBUG_PREFIX_MAP:remove = "-fcanon-prefix-map"
 
 SRC_URI = "git://android.googlesource.com/kernel/msm;branch=android-msm-triggerfish-4.9-pie-wear-mr1;protocol=https \
            file://defconfig \

--- a/meta-triggerfish/recipes-kernel/linux/linux-triggerfish_p.bb
+++ b/meta-triggerfish/recipes-kernel/linux/linux-triggerfish_p.bb
@@ -18,6 +18,7 @@ SRC_URI = "git://android.googlesource.com/kernel/msm;branch=android-msm-triggerf
            file://0001-Add-Fossil-device-tree-files.patch \
            file://0002-scripts-dtc-Remove-redundant-YYLOC-global-declaratio.patch \
            file://0003-Force-triggerfish-DTB-to-build.patch \
+           file://0004-ARM-8933-1-replace-Sun-Solaris-style-flag-on-section.patch \
            "
 
 SRCREV = "82824770e036a1e7576a299bc37b52d633d62675"

--- a/meta-wren/recipes-kernel/linux/linux-wren/0022-ARM-8933-1-replace-Sun-Solaris-style-flag-on-section.patch
+++ b/meta-wren/recipes-kernel/linux/linux-wren/0022-ARM-8933-1-replace-Sun-Solaris-style-flag-on-section.patch
@@ -1,0 +1,116 @@
+From 52b7b0ea9d9e4672dfc742f71cc6b08a8d10ffa7 Mon Sep 17 00:00:00 2001
+From: casept <davids.paskevics@gmail.com>
+Date: Sun, 16 Jun 2024 00:51:52 +0200
+Subject: [PATCH] ARM: 8933/1: replace Sun/Solaris style flag on section
+ directive
+
+It looks like a section directive was using "Solaris style" to declare
+the section flags. Replace this with the GNU style so that Clang's
+integrated assembler can assemble this directive.
+
+The modified instances were identified via:
+$ ag \.section | grep #
+
+Link: https://ftp.gnu.org/old-gnu/Manuals/gas-2.9.1/html_chapter/as_7.html#SEC119
+Link: https://github.com/ClangBuiltLinux/linux/issues/744
+Link: https://bugs.llvm.org/show_bug.cgi?id=43759
+Link: https://reviews.llvm.org/D69296
+
+Acked-by: Nicolas Pitre <nico@fluxnic.net>
+Reviewed-by: Ard Biesheuvel <ardb@kernel.org>
+Reviewed-by: Stefan Agner <stefan@agner.ch>
+Signed-off-by: Nick Desaulniers <ndesaulniers@google.com>
+Suggested-by: Fangrui Song <maskray@google.com>
+Suggested-by: Jian Cai <jiancai@google.com>
+Suggested-by: Peter Smith <peter.smith@linaro.org>
+Signed-off-by: Russell King <rmk+kernel@armlinux.org.uk>
+[ partial backport to 3.10 ]
+---
+ arch/arm/boot/compressed/big-endian.S   | 2 +-
+ arch/arm/boot/compressed/head.S         | 2 +-
+ arch/arm/boot/compressed/piggy.gzip.S   | 2 +-
+ arch/arm/boot/compressed/piggy.lzma.S   | 2 +-
+ arch/arm/boot/compressed/piggy.lzo.S    | 2 +-
+ arch/arm/boot/compressed/piggy.xzkern.S | 2 +-
+ arch/arm/mm/proc-v7.S                   | 2 +-
+ 7 files changed, 7 insertions(+), 7 deletions(-)
+
+diff --git a/arch/arm/boot/compressed/big-endian.S b/arch/arm/boot/compressed/big-endian.S
+index 25ab26f1c6f0..f22428e275f8 100644
+--- a/arch/arm/boot/compressed/big-endian.S
++++ b/arch/arm/boot/compressed/big-endian.S
+@@ -5,7 +5,7 @@
+  *  Author: Nicolas Pitre
+  */
+ 
+-	.section ".start", #alloc, #execinstr
++	.section ".start", "ax"
+ 
+ 	mrc	p15, 0, r0, c1, c0, 0	@ read control reg
+ 	orr	r0, r0, #(1 << 7)	@ enable big endian mode
+diff --git a/arch/arm/boot/compressed/head.S b/arch/arm/boot/compressed/head.S
+index fdd2e354ba3f..c5057234b014 100644
+--- a/arch/arm/boot/compressed/head.S
++++ b/arch/arm/boot/compressed/head.S
+@@ -114,7 +114,7 @@
+ #endif
+ 		.endm
+ 
+-		.section ".start", #alloc, #execinstr
++		.section ".start", "ax"
+ /*
+  * sort out different calling conventions
+  */
+diff --git a/arch/arm/boot/compressed/piggy.gzip.S b/arch/arm/boot/compressed/piggy.gzip.S
+index a68adf91a165..175ed02a6ac3 100644
+--- a/arch/arm/boot/compressed/piggy.gzip.S
++++ b/arch/arm/boot/compressed/piggy.gzip.S
+@@ -1,4 +1,4 @@
+-	.section .piggydata,#alloc
++	.section .piggydata, "a"
+ 	.globl	input_data
+ input_data:
+ 	.incbin	"arch/arm/boot/compressed/piggy.gzip"
+diff --git a/arch/arm/boot/compressed/piggy.lzma.S b/arch/arm/boot/compressed/piggy.lzma.S
+index d7e69cffbc0a..cfea81ae8f4b 100644
+--- a/arch/arm/boot/compressed/piggy.lzma.S
++++ b/arch/arm/boot/compressed/piggy.lzma.S
+@@ -1,4 +1,4 @@
+-	.section .piggydata,#alloc
++	.section .piggydata, "a"
+ 	.globl	input_data
+ input_data:
+ 	.incbin	"arch/arm/boot/compressed/piggy.lzma"
+diff --git a/arch/arm/boot/compressed/piggy.lzo.S b/arch/arm/boot/compressed/piggy.lzo.S
+index a425ad95959a..236976d8dc7d 100644
+--- a/arch/arm/boot/compressed/piggy.lzo.S
++++ b/arch/arm/boot/compressed/piggy.lzo.S
+@@ -1,4 +1,4 @@
+-	.section .piggydata,#alloc
++	.section .piggydata, "a"
+ 	.globl	input_data
+ input_data:
+ 	.incbin	"arch/arm/boot/compressed/piggy.lzo"
+diff --git a/arch/arm/boot/compressed/piggy.xzkern.S b/arch/arm/boot/compressed/piggy.xzkern.S
+index 5703f300d027..a135d3b549c5 100644
+--- a/arch/arm/boot/compressed/piggy.xzkern.S
++++ b/arch/arm/boot/compressed/piggy.xzkern.S
+@@ -1,4 +1,4 @@
+-	.section .piggydata,#alloc
++	.section .piggydata, "a"
+ 	.globl	input_data
+ input_data:
+ 	.incbin	"arch/arm/boot/compressed/piggy.xzkern"
+diff --git a/arch/arm/mm/proc-v7.S b/arch/arm/mm/proc-v7.S
+index 1f8597462b3a..050e3da34b9f 100644
+--- a/arch/arm/mm/proc-v7.S
++++ b/arch/arm/mm/proc-v7.S
+@@ -417,7 +417,7 @@ __v7_setup_stack:
+ 	string	cpu_elf_name, "v7"
+ 	.align
+ 
+-	.section ".proc.info.init", #alloc, #execinstr
++	.section ".proc.info.init", "ax"
+ 
+ 	/*
+ 	 * Standard v7 proc info content

--- a/meta-wren/recipes-kernel/linux/linux-wren_mm-mr1.bb
+++ b/meta-wren/recipes-kernel/linux/linux-wren_mm-mr1.bb
@@ -30,6 +30,7 @@ SRC_URI = "git://android.googlesource.com/kernel/msm;branch=android-msm-wren-3.1
     file://0019-Use-normal-touch-handling-all-the-time.patch \
     file://0020-Disable-isTouchLocked.patch \
     file://0021-ARM-uaccess-remove-put_user-code-duplication.patch \
+    file://0022-ARM-8933-1-replace-Sun-Solaris-style-flag-on-section.patch \
     file://defconfig \
     file://img_info "
 SRCREV = "00f21f748f01888888909f9f58280f5a363cd5f9"


### PR DESCRIPTION
Basically all of them needed various kernel patches applied, and some also required fairly minor userspace fixup.

sparrow-mainline's kernel still doesn't build, it's probably possible to fix by either re-basing onto a newer kernel version or downgrading GCC.

tetra requires some fixes in it's sensorfw patches which I haven't tackled.

I've only tested on catfish, as I don't own any other supported watches. These changes get it booting, but the binder issue that you talked about on Matrix still occurs and prevents `asteroid-launcher` from starting.

There's a companion pull request against your scarthgap branch for `meta-asteroid`.